### PR TITLE
docs: project documentation (CLAUDE.md + docs/) and README refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ next-env.d.ts
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+
+# IDE
+/.idea/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,96 @@
+# CLAUDE.md
+
+Guidance for AI agents and contributors working in this repo. Read this before making changes. Deeper references live in [`docs/`](docs/).
+
+## What this is
+
+Zmanim — halachic Jewish prayer times + calendar for any location, trilingual (English / Hebrew RTL / Russian). Times are computed **in-app** with [`kosher-zmanim`](https://github.com/BehindTheMath/KosherZmanim) and cross-validated to the second against Hebcal.
+
+**Zmanim correctness is the product.** Treat the domain layer (`src/lib/zmanim`, `src/lib/calendar`) as safety-critical: never change a calculation, a `key → method` mapping, or a description without a test that pins the expected behavior. When in doubt about a halachic meaning, verify against an authoritative source (KosherJava javadocs, myzmanim) — don't guess.
+
+## Commands
+
+| Command | Purpose |
+| --- | --- |
+| `npm run dev` | Dev server (Turbopack) on `0.0.0.0:3000` |
+| `npm run lint` | ESLint (flat config, `next/core-web-vitals` + TS) |
+| `npm run typecheck` | `tsc --noEmit` |
+| `npm test` | Vitest (unit / golden / invariant / edge) |
+| `npm run test:e2e` | Playwright |
+| `npm run build` | Production build (standalone output) |
+
+Run **lint + typecheck + test** after any change; they are the CI gate.
+
+## Stack & version gotchas
+
+- **Next.js 16** App Router, React 19, **React Compiler is on**:
+  - Do **not** write manual `useMemo`/`useCallback` — the compiler memoizes, and `react-hooks/preserve-manual-memoization` will flag it.
+  - Do **not** `setState` inside an effect (`react-hooks/set-state-in-effect`). For a client-only mount gate use `useSyncExternalStore` (see `src/components/app.tsx`), not `useEffect` + state.
+  - The middleware file is **`src/proxy.ts`**, not `middleware.ts` — Next 16 renamed it. Older tooling/linters (and GitHub Copilot review) will wrongly claim it "won't run." It does.
+- **next-intl v4**: `NextIntlClientProvider` inherits `messages`/`locale` from the request config (`src/i18n/request.ts`) — it deliberately does **not** take a `messages` prop. Catalogs are `messages/{en,he,ru}.json`. Server components call `setRequestLocale(locale)` before reading translations.
+- **Tailwind v4**: CSS-based config in `src/app/globals.css` (`@theme`, oklch tokens). Merge classes with `cn()` from `@/lib/utils`.
+- **shadcn/ui** components live in `src/components/ui/` (RTL enabled, generated via `components.json`). Prefer composing these over new primitives.
+- **No `React.ReactNode`** without importing `ReactNode` — import the type explicitly (avoids relying on the React UMD global).
+
+## Architecture map
+
+```
+src/
+  app/[locale]/            routes: home, /zmanim (city index), /zmanim/[city] (ISR SEO)
+  app/{sitemap,robots,manifest}.ts
+  components/
+    app.tsx                client shell: layout, providers, mount gate
+    calendar/              calendar-grid, calendar-day, calendar-view, day-style
+    zmanim/                zmanim-panel, zmanim-list, next-zman, shita-info
+    layout/ providers/ ui/
+  hooks/                   use-zmanim, use-geolocation
+  i18n/                    routing, request, navigation (next-intl)
+  lib/
+    zmanim/                definitions (locked mapping), calculator, groups, types
+    calendar/              grid, navigation, day-info, day-events, holidays-ru
+    geo/                   geocoding (keyless), timezone (offline)
+    location.ts site.ts cities.ts format.ts utils.ts
+messages/                  en / he / ru catalogs
+proxy.ts                   next-intl middleware (Next 16 name)
+```
+
+Data flow: `app-state` (selected day, location, candle offset) → `use-zmanim` → `computeZmanim()` → `buildZmanimGroups()` → panel; the calendar grid computes per-cell `getDayInfo` + `getDayEvents`. The calendar renders **client-only after mount** so "today"/selection can't cause a hydration mismatch.
+
+See [`docs/architecture.md`](docs/architecture.md) for the full narrative.
+
+## Critical correctness rules (do not break)
+
+1. **Timezone day handling** — build a calendar day's noon from date *components* in the target zone: `DateTime.fromObject({year,month,day,hour:12},{zone:tz})`. Never `setZone()` an instant to derive the day (it shifts across tz/DST). Convert each computed time with `.setZone(tz)`. A golden test catches regressions.
+2. **Work-prohibited day** — use `isYomTovAssurBemelacha()`, **not** the broad `isYomTov()` (true for Purim/Chanukah). Chanukah classifies as `weekday` in `classify()`.
+3. **Israel vs diaspora** — `location.inIsrael` (tz `=== 'Asia/Jerusalem'`) is threaded through `getDayInfo`/`getDayEvents`; it changes the parsha schedule and 1- vs 2-day Yom Tov. Persisted locations missing `inIsrael` are backfilled.
+4. **Week parsha** — `kosher-zmanim`'s `getUpcomingParsha()` is broken in 0.9 (throws). Compute it by walking to the coming Saturday.
+5. **`candleLighting` is returned every day** by `computeZmanim` (sunset − offset). It is only a real zman on Erev Shabbat / Erev Yom Tov — filter it out elsewhere (e.g. the "next zman" banner gates it on `isErev`).
+6. **Descriptions** — verified against KosherJava/myzmanim. The "≈ X min before sunrise" figures on degree-based zmanim are the **Jerusalem-equinox anchor** and vary by location/season; keep that qualifier. Details in [`docs/zmanim.md`](docs/zmanim.md).
+
+## UI / responsive conventions
+
+- **Fixed-viewport calendar**: the month always fits the screen (no page scroll). The shell is `h-dvh` (desktop) and the grid rows are `repeat(weeks, minmax(0,1fr))`; the zmanim panel scrolls internally.
+- **Largest text size (`xxl`)** can't fit a full month — cells fall back to a compact view (big number + significant-day dot + alternate-calendar date) via `CalendarGrid`'s `compact` flag (driven by `accessibility-provider`'s font scale). `lg`/`xl` keep the fixed viewport. Mobile always uses the compact cells; full detail is in the day panel.
+- **Accessibility text scaling** uses `--ui-scale` on `html { font-size }`. Any text that should grow must use **rem-based** sizes — a fixed `text-[11px]` will not scale. Prefer rem arbitrary values (`text-[0.6875rem]`).
+- **Day colors**: `src/components/calendar/day-style.ts` `DAY_TONE` + `significantTone()` are the single source for significant-day colors — used by both the grid dot and the panel chip, so they always match. Edit there.
+- **Touch-friendly disclosure**: use a tap/click `Popover` (see `ShitaInfo`), never a hover-only `title`, for content users need on mobile.
+
+## i18n / translations
+
+- Terminology is unified with the companion `zmanim_bot` project: transliterated zman names; readable opinion labels ("Vilna Gaon" / "Magen Avraham").
+- **HE/EN** holiday & parsha names come from the `kosher-zmanim` formatter. Only **Russian** holiday names are overridden, in `src/lib/calendar/holidays-ru.ts`.
+- A zman's visible whole-zman caption is `zmanim.baseDescriptions`; the per-opinion detail is `zmanim.descriptions` (shown behind the info popover).
+
+## Deployment
+
+Image-only CI (`.github/workflows/ci.yml`): lint/typecheck/test/build + Playwright gate, then **build & push** `ghcr.io/<repo>:latest` and `:sha` on push to `main`. There is **no auto-deploy** — pull + `docker compose up -d` on the server manually. The app has **no runtime secrets** (all client-side). Full guide: [`docs/deployment.md`](docs/deployment.md).
+
+- The committed **`package-lock.json` must be cross-platform** because CI uses strict `npm ci`. If you change dependencies, regenerate the lockfile on Linux or CI will fail with `EUSAGE` (missing Linux/WASM optional deps):
+  ```bash
+  docker run --rm -v "$PWD":/w -w /w node:22-slim npm install --package-lock-only --no-audit --no-fund
+  ```
+
+## Conventions
+
+- **Conventional Commits** enforced by commitlint (husky `commit-msg`); `pre-commit` runs `eslint --fix` via lint-staged.
+- **No AI/agent attribution anywhere** — commits, PR titles/bodies, code comments, authors. This is the maintainer's standing rule; keep all output clean of it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,8 +50,8 @@ src/
     calendar/              grid, navigation, day-info, day-events, holidays-ru
     geo/                   geocoding (keyless), timezone (offline)
     location.ts site.ts cities.ts format.ts utils.ts
+  proxy.ts                 next-intl middleware (Next 16's renamed middleware.ts)
 messages/                  en / he / ru catalogs
-proxy.ts                   next-intl middleware (Next 16 name)
 ```
 
 Data flow: `app-state` (selected day, location, candle offset) → `use-zmanim` → `computeZmanim()` → `buildZmanimGroups()` → panel; the calendar grid computes per-cell `getDayInfo` + `getDayEvents`. The calendar renders **client-only after mount** so "today"/selection can't cause a hydration mismatch.
@@ -83,7 +83,7 @@ See [`docs/architecture.md`](docs/architecture.md) for the full narrative.
 
 ## Deployment
 
-Image-only CI (`.github/workflows/ci.yml`): lint/typecheck/test/build + Playwright gate, then **build & push** `ghcr.io/<repo>:latest` and `:sha` on push to `main`. There is **no auto-deploy** — pull + `docker compose up -d` on the server manually. The app has **no runtime secrets** (all client-side). Full guide: [`docs/deployment.md`](docs/deployment.md).
+Image-only CI (`.github/workflows/ci.yml`): lint/typecheck/test/build + Playwright gate, then **build & push** `ghcr.io/<repo>:latest` and `:sha-<commit>` on push to `main`. There is **no auto-deploy** — pull + `docker compose up -d` on the server manually. The app has **no runtime secrets** (all client-side). Full guide: [`docs/deployment.md`](docs/deployment.md).
 
 - The committed **`package-lock.json` must be cross-platform** because CI uses strict `npm ci`. If you change dependencies, regenerate the lockfile on Linux or CI will fail with `EUSAGE` (missing Linux/WASM optional deps):
   ```bash

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ npm install
 npm run dev          # http://localhost:3000
 ```
 
-Copy `.env.example` to `.env` and set `NEXT_PUBLIC_SITE_URL` for correct SEO URLs.
+`NEXT_PUBLIC_SITE_URL` defaults to `http://localhost:3000`; set it (env or repo variable) for correct SEO URLs in production.
+
+> Working on the code? Start with [`CLAUDE.md`](CLAUDE.md), then [`docs/`](docs/) — [architecture](docs/architecture.md), [zmanim domain](docs/zmanim.md), [deployment](docs/deployment.md).
 
 ### Scripts
 
@@ -52,7 +54,7 @@ i18n routing and dynamic deep-links — it is **not** a static site).
 docker compose up --build          # serves on 127.0.0.1:3000
 ```
 
-On the server, CI pushes an image to GHCR; deploy with:
+CI builds and pushes an image to GHCR (it does **not** auto-deploy). On the server:
 
 ```bash
 docker compose pull
@@ -66,12 +68,10 @@ Put your host nginx in front as a reverse proxy — see [`deploy/nginx.conf`](de
 
 `.github/workflows/ci.yml`:
 
-- **Every push/PR:** lint, typecheck, test, build
-- **Push to `main`:** build the Docker image, push to GHCR, then SSH to the server and `docker compose pull && up -d`
+- **Every push/PR to `main`:** lint, typecheck, test, build + Playwright e2e
+- **Push to `main`:** build the Docker image and push to GHCR (`:latest` + `:sha`)
 
-Required repository **secrets**: `SSH_HOST`, `SSH_USER`, `SSH_PRIVATE_KEY`, `DEPLOY_DIR`.
-Required repository **variable**: `NEXT_PUBLIC_SITE_URL`.
-The server must have Docker + a `docker-compose.yml` referencing the GHCR image, and be able to pull it.
+Required repository **variable**: `NEXT_PUBLIC_SITE_URL`. No secrets are needed (no auto-deploy, no runtime tokens). See [`docs/deployment.md`](docs/deployment.md) for server setup, GHCR auth, and the cross-platform lockfile requirement.
 
 ## Project structure
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Put your host nginx in front as a reverse proxy — see [`deploy/nginx.conf`](de
 `.github/workflows/ci.yml`:
 
 - **Every push/PR to `main`:** lint, typecheck, test, build + Playwright e2e
-- **Push to `main`:** build the Docker image and push to GHCR (`:latest` + `:sha`)
+- **Push to `main`:** build the Docker image and push to GHCR (`:latest` + `:sha-<commit>`)
 
 Required repository **variable**: `NEXT_PUBLIC_SITE_URL`. No secrets are needed (no auto-deploy, no runtime tokens). See [`docs/deployment.md`](docs/deployment.md) for server setup, GHCR auth, and the cross-platform lockfile requirement.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,20 +7,20 @@ How the app is put together and why. For the halachic domain specifics see [zman
 The codebase is split into a **pure domain layer** and a **UI layer**, with a thin state/provider seam between them.
 
 ```
-lib/  (pure, framework-free, unit-tested)
+src/lib/  (pure, framework-free, unit-tested)
   zmanim/     time computation + display grouping
   calendar/   month grid, day classification, day events, navigation
   geo/        geocoding + timezone
   location.ts site.ts cities.ts format.ts
 
-components/providers/  client state (app-state, accessibility, theme, query)
-hooks/                 use-zmanim, use-geolocation
+src/components/providers/  client state (app-state, accessibility, theme, query)
+src/hooks/                 use-zmanim, use-geolocation
 
-components/  (presentational; read state via hooks/providers)
-app/         routes + metadata
+src/components/  (presentational; read state via hooks/providers)
+src/app/         routes + metadata
 ```
 
-Everything under `lib/` is deterministic and has no React/Next imports, so it can be unit-tested in isolation and reused on both server (SEO city pages) and client. UI components stay thin and read derived data from hooks.
+Everything under `src/lib/` is deterministic and has no React/Next imports, so it can be unit-tested in isolation and reused on both server (SEO city pages) and client. UI components stay thin and read derived data from hooks.
 
 ## State
 
@@ -33,15 +33,15 @@ Two client providers hold app state (no global store, no server state for the co
 
 ### Hydration strategy
 
-The calendar depends on "today" and the selected day, which differ between server and client. To avoid hydration mismatches, `components/app.tsx` gates the real UI behind a client-only mount check (`useIsClient` via `useSyncExternalStore`) and renders a skeleton during SSR. Because the calendar tree only mounts on the client, components inside it (e.g. `CalendarGrid` reading the accessibility font scale) can safely use client-only values.
+The calendar depends on "today" and the selected day, which differ between server and client. To avoid hydration mismatches, `src/components/app.tsx` gates the real UI behind a client-only mount check (`useIsClient` via `useSyncExternalStore`) and renders a skeleton during SSR. Because the calendar tree only mounts on the client, components inside it (e.g. `CalendarGrid` reading the accessibility font scale) can safely use client-only values.
 
 ## Rendering & routes
 
-- `app/[locale]/layout.tsx` — fonts, `<html dir>` per locale, theme + accessibility + next-intl providers, `viewport`/`metadata`. `generateStaticParams` pre-renders the three locales.
-- `app/[locale]/page.tsx` — home; supports deep-linked location.
-- `app/[locale]/zmanim/page.tsx` — city index; `app/[locale]/zmanim/[city]/page.tsx` — per-city SEO page (ISR), server-rendered using the same `lib/` domain code.
-- `app/{sitemap,robots,manifest}.ts` — generated metadata routes (server, build-time).
-- `proxy.ts` — next-intl locale middleware (Next 16's renamed `middleware.ts`).
+- `src/app/[locale]/layout.tsx` — fonts, `<html dir>` per locale, theme + accessibility + next-intl providers, `viewport`/`metadata`. `generateStaticParams` pre-renders the three locales.
+- `src/app/[locale]/page.tsx` — home; supports deep-linked location.
+- `src/app/[locale]/zmanim/page.tsx` — city index; `src/app/[locale]/zmanim/[city]/page.tsx` — per-city SEO page (ISR), server-rendered using the same `src/lib/` domain code.
+- `src/app/{sitemap,robots,manifest}.ts` — generated metadata routes (server, build-time).
+- `src/proxy.ts` — next-intl locale middleware (Next 16's renamed `middleware.ts`).
 
 Because of ISR, locale routing, and dynamic deep-links, the app is **not** a static export — it runs as a standalone Node server in the container.
 
@@ -49,8 +49,8 @@ Because of ISR, locale routing, and dynamic deep-links, the app is **not** a sta
 
 ```
 app-state (day, location, offset)
-  → use-zmanim → computeZmanim()        // lib/zmanim/calculator.ts
-  → buildZmanimGroups()                 // lib/zmanim/groups.ts (day-part → base → shitot)
+  → use-zmanim → computeZmanim()        // src/lib/zmanim/calculator.ts
+  → buildZmanimGroups()                 // src/lib/zmanim/groups.ts (day-part → base → shitot)
   → ZmanimPanel / ZmanimList
 ```
 
@@ -60,7 +60,7 @@ See [zmanim.md](zmanim.md) for `definitions.ts` (the locked `key → method` map
 
 ## The calendar
 
-`CalendarGrid` builds a dynamic month grid (`lib/calendar/grid.ts`, 4–6 week rows) and computes, per cell, `getDayInfo` (category, holiday label, parsha, omer, rosh chodesh…) and `getDayEvents` (candle/havdalah/fast times). `CalendarDay` renders a cell.
+`CalendarGrid` builds a dynamic month grid (`src/lib/calendar/grid.ts`, 4–6 week rows) and computes, per cell, `getDayInfo` (category, holiday label, parsha, omer, rosh chodesh…) and `getDayEvents` (candle/havdalah/fast times). `CalendarDay` renders a cell.
 
 ### Responsive / fixed-viewport layout
 
@@ -72,7 +72,7 @@ The defining UI constraint: **the month must always fit the screen without scrol
 
 ### Color system
 
-`components/calendar/day-style.ts` is the single source of truth for significant-day colors. `significantTone(category, dayOfChanukah)` maps a day to a `DayTone`, and `DAY_TONE[tone]` provides matching `chip` (panel) and `dot` (grid) classes — so the grid dot and the panel chip for the same day can never drift apart.
+`src/components/calendar/day-style.ts` is the single source of truth for significant-day colors. `significantTone(category, dayOfChanukah)` maps a day to a `DayTone`, and `DAY_TONE[tone]` provides matching `chip` (panel) and `dot` (grid) classes — so the grid dot and the panel chip for the same day can never drift apart.
 
 ## Accessibility
 
@@ -82,8 +82,8 @@ The defining UI constraint: **the month must always fit the screen without scrol
 
 ## i18n
 
-`next-intl` with locale-prefixed routing (`as-needed`: `/`, `/he`, `/ru`). `i18n/request.ts` loads `messages/{locale}.json` per request; the client provider inherits them (no `messages` prop). Display terminology is unified with the companion `zmanim_bot`. HE/EN holiday & parsha names come from the `kosher-zmanim` formatter; only Russian holiday names are overridden (`lib/calendar/holidays-ru.ts`).
+`next-intl` with locale-prefixed routing (`as-needed`: `/`, `/he`, `/ru`). `src/i18n/request.ts` loads `messages/{locale}.json` per request; the client provider inherits them (no `messages` prop). Display terminology is unified with the companion `zmanim_bot`. HE/EN holiday & parsha names come from the `kosher-zmanim` formatter; only Russian holiday names are overridden (`src/lib/calendar/holidays-ru.ts`).
 
 ## Geo (keyless, no tokens)
 
-`lib/geo/geocoding.ts` — forward city search via **Open-Meteo**, reverse (coords → name) via **BigDataCloud**'s free client endpoint. `lib/geo/timezone.ts` — timezone resolved **offline** with `tz-lookup`. There are no API keys anywhere; the legacy Mapbox dependency was intentionally dropped.
+`src/lib/geo/geocoding.ts` — forward city search via **Open-Meteo**, reverse (coords → name) via **BigDataCloud**'s free client endpoint. `src/lib/geo/timezone.ts` — timezone resolved **offline** with `tz-lookup`. There are no API keys anywhere; the legacy Mapbox dependency was intentionally dropped.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,89 @@
+# Architecture
+
+How the app is put together and why. For the halachic domain specifics see [zmanim.md](zmanim.md); for ops see [deployment.md](deployment.md).
+
+## Layering
+
+The codebase is split into a **pure domain layer** and a **UI layer**, with a thin state/provider seam between them.
+
+```
+lib/  (pure, framework-free, unit-tested)
+  zmanim/     time computation + display grouping
+  calendar/   month grid, day classification, day events, navigation
+  geo/        geocoding + timezone
+  location.ts site.ts cities.ts format.ts
+
+components/providers/  client state (app-state, accessibility, theme, query)
+hooks/                 use-zmanim, use-geolocation
+
+components/  (presentational; read state via hooks/providers)
+app/         routes + metadata
+```
+
+Everything under `lib/` is deterministic and has no React/Next imports, so it can be unit-tested in isolation and reused on both server (SEO city pages) and client. UI components stay thin and read derived data from hooks.
+
+## State
+
+Two client providers hold app state (no global store, no server state for the core flow):
+
+- **`app-state.tsx`** — `selectedDay`, `location` (lat/lng/tz/label/`inIsrael`), `monthDate`, `mode` (gregorian/hebrew), `candleLightingOffset`. Persists the selected day in the URL (`?d=…&m=…`) for shareable deep-links and restores from it on mount.
+- **`accessibility-provider.tsx`** — `fontScale` (default/lg/xl/xxl), `reduceMotion`, `highContrast`. Read from `localStorage` in the `useState` initializer (matches a no-flash inline script in the layout that applies the html classes before paint), then applies html classes + persists in an effect.
+
+`query-provider.tsx` holds a stable `QueryClient` for the geocoding search; `theme-provider.tsx` is `next-themes`.
+
+### Hydration strategy
+
+The calendar depends on "today" and the selected day, which differ between server and client. To avoid hydration mismatches, `components/app.tsx` gates the real UI behind a client-only mount check (`useIsClient` via `useSyncExternalStore`) and renders a skeleton during SSR. Because the calendar tree only mounts on the client, components inside it (e.g. `CalendarGrid` reading the accessibility font scale) can safely use client-only values.
+
+## Rendering & routes
+
+- `app/[locale]/layout.tsx` — fonts, `<html dir>` per locale, theme + accessibility + next-intl providers, `viewport`/`metadata`. `generateStaticParams` pre-renders the three locales.
+- `app/[locale]/page.tsx` — home; supports deep-linked location.
+- `app/[locale]/zmanim/page.tsx` — city index; `app/[locale]/zmanim/[city]/page.tsx` — per-city SEO page (ISR), server-rendered using the same `lib/` domain code.
+- `app/{sitemap,robots,manifest}.ts` — generated metadata routes (server, build-time).
+- `proxy.ts` — next-intl locale middleware (Next 16's renamed `middleware.ts`).
+
+Because of ISR, locale routing, and dynamic deep-links, the app is **not** a static export — it runs as a standalone Node server in the container.
+
+## The zmanim display pipeline
+
+```
+app-state (day, location, offset)
+  → use-zmanim → computeZmanim()        // lib/zmanim/calculator.ts
+  → buildZmanimGroups()                 // lib/zmanim/groups.ts (day-part → base → shitot)
+  → ZmanimPanel / ZmanimList
+```
+
+The panel header also shows significant-day **chips** (`buildDayChips`) and a **times strip** (candle lighting / havdalah / fasts) computed for the whole rest-period the day belongs to (so both bookends show on Friday and Saturday). `NextZman` is a live countdown shown only for today.
+
+See [zmanim.md](zmanim.md) for `definitions.ts` (the locked `key → method` map), the timezone-correct calculator, and grouping.
+
+## The calendar
+
+`CalendarGrid` builds a dynamic month grid (`lib/calendar/grid.ts`, 4–6 week rows) and computes, per cell, `getDayInfo` (category, holiday label, parsha, omer, rosh chodesh…) and `getDayEvents` (candle/havdalah/fast times). `CalendarDay` renders a cell.
+
+### Responsive / fixed-viewport layout
+
+The defining UI constraint: **the month must always fit the screen without scrolling.**
+
+- The shell is `h-dvh` with `overflow-hidden` on desktop; the grid rows are `repeat(weeks, minmax(0,1fr))` so they divide the available height. The zmanim panel scrolls internally.
+- **Mobile**: cells are compact — a day number, a single significant-day **dot**, and the alternate-calendar date. Full per-day detail lives in the panel (tap a day). The page scrolls (calendar then panel).
+- **Largest accessibility text size (`xxl`)**: a full month can't fit at 1.4× text, so desktop cells also fall back to the compact view via `CalendarGrid`'s `compact` flag (derived from the accessibility font scale). `lg`/`xl` keep the fixed viewport.
+
+### Color system
+
+`components/calendar/day-style.ts` is the single source of truth for significant-day colors. `significantTone(category, dayOfChanukah)` maps a day to a `DayTone`, and `DAY_TONE[tone]` provides matching `chip` (panel) and `dot` (grid) classes — so the grid dot and the panel chip for the same day can never drift apart.
+
+## Accessibility
+
+- **Text scaling** uses a CSS variable: `html { font-size: calc(100% * var(--ui-scale) * var(--ui-screen)) }`. The `.text-scale-{lg,xl,xxl}` classes set `--ui-scale`; a small `--ui-screen` bump applies on very wide screens. **Consequence:** only **rem-based** sizes scale — never size text in fixed `px` if it should grow.
+- `reduce-motion` kills animations; `high-contrast` overrides muted/border tokens.
+- Touch-reachable disclosure: `ShitaInfo` uses a tap/click `Popover`, not a hover `title`.
+
+## i18n
+
+`next-intl` with locale-prefixed routing (`as-needed`: `/`, `/he`, `/ru`). `i18n/request.ts` loads `messages/{locale}.json` per request; the client provider inherits them (no `messages` prop). Display terminology is unified with the companion `zmanim_bot`. HE/EN holiday & parsha names come from the `kosher-zmanim` formatter; only Russian holiday names are overridden (`lib/calendar/holidays-ru.ts`).
+
+## Geo (keyless, no tokens)
+
+`lib/geo/geocoding.ts` — forward city search via **Open-Meteo**, reverse (coords → name) via **BigDataCloud**'s free client endpoint. `lib/geo/timezone.ts` — timezone resolved **offline** with `tz-lookup`. There are no API keys anywhere; the legacy Mapbox dependency was intentionally dropped.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,82 @@
+# Deployment
+
+Self-hosted Docker. The app runs as a standalone Node server in a container (it needs a runtime for ISR, locale routing, and dynamic deep-links — it is **not** a static site).
+
+## Pipeline overview
+
+CI (`.github/workflows/ci.yml`) is **image-only** — it builds and publishes a Docker image but does **not** deploy. You pull and restart the stack on the server yourself.
+
+```
+push / PR → main:   lint · typecheck · test · build   (job: ci)
+                    Playwright e2e                    (job: e2e)
+push → main only:   build & push image to GHCR        (job: image)
+```
+
+The `image` job pushes `ghcr.io/<owner>/<repo>:latest` and `:sha-<commit>` and runs only after `ci` + `e2e` pass.
+
+## What you must configure
+
+- **Repository variable** `NEXT_PUBLIC_SITE_URL` — the production origin (e.g. `https://zmanim.example`). It is inlined at **build time** for SEO (`metadataBase`, sitemap, robots, canonical/OG URLs). It is public by design and is **not** a secret.
+- **No deploy secrets** and **no runtime secrets.** The app has no server-side tokens (geocoding is keyless, timezone is offline). There is nothing sensitive to inject.
+
+## docker-compose.yml
+
+`docker-compose.yml` defaults to the published image and sane values, so on the server `docker compose up -d` works with no `.env`:
+
+```yaml
+image: ${ZMANIM_IMAGE:-ghcr.io/benyaming/zmanim_site:latest}
+ports: ["0.0.0.0:${ZMANIM_PORT:-3000}:3000"]
+```
+
+A `.env` on the server is **optional** — only to override a default:
+
+```env
+ZMANIM_PORT=8080
+# pin a build for rollback instead of :latest
+ZMANIM_IMAGE=ghcr.io/benyaming/zmanim_site:sha-1a2b3c4
+```
+
+`NEXT_PUBLIC_SITE_URL` is **not** needed on the server — it's already baked into the pulled image. (It only appears under `build.args`, used for local `docker compose up --build`.)
+
+## Server setup (one-time)
+
+1. Install Docker + the compose plugin.
+2. Create a deploy directory and put `docker-compose.yml` in it.
+3. Allow the server to pull the GHCR image (it's private by default), one of:
+   - `docker login ghcr.io -u <user> -p <GitHub PAT with read:packages>`, or
+   - make the GHCR package public (Package → settings → change visibility).
+4. Put a reverse proxy (nginx/Caddy) with TLS in front of the bound port — see [`deploy/nginx.conf`](../deploy/nginx.conf). The app owns `/zmanim/*`, so remove any old `location /zmanim { proxy_pass … }` rule.
+
+## Deploying a new version
+
+After a merge to `main` finishes the `image` job:
+
+```bash
+cd <deploy-dir>
+docker compose pull
+docker compose up -d
+docker image prune -f   # optional
+```
+
+The compose stack has a healthcheck; `docker compose ps` shows health.
+
+## Docker build notes
+
+`Dockerfile` is multi-stage: deps → build → a minimal non-root runtime that copies Next's `standalone` output. It installs with `npm ci || npm install` — the fallback exists because Alpine/musl native deps aren't always in a lockfile generated elsewhere.
+
+## Lockfile must stay cross-platform
+
+CI uses strict **`npm ci`**, which fails if `package-lock.json` is missing any platform's optional deps. A lockfile generated on macOS can omit Linux/WASM deps (`@emnapi/*`, `@swc/helpers`, native `*-linux-*` binaries) and break CI with `EUSAGE`. After changing dependencies, regenerate the lockfile on Linux:
+
+```bash
+docker run --rm -v "$PWD":/w -w /w node:22-slim \
+  npm install --package-lock-only --no-audit --no-fund
+```
+
+To verify before pushing, `npm ci` in a clean Linux container:
+
+```bash
+mkdir -p /tmp/lc && cp package.json package-lock.json /tmp/lc/ && \
+docker run --rm -v /tmp/lc:/w -w /w node:22-slim \
+  sh -c 'npm ci --ignore-scripts --no-audit --no-fund && echo OK'
+```

--- a/docs/zmanim.md
+++ b/docs/zmanim.md
@@ -1,0 +1,75 @@
+# Zmanim domain
+
+The halachic engine and calendar logic. This is the safety-critical part of the app — changes here need tests that pin expected behavior, and halachic meanings should be verified against authoritative sources, not memory.
+
+Sources used for the descriptions and definitions:
+- KosherJava javadocs (authoritative for the library this app uses) — <https://kosherjava.com/zmanim/docs/api/>
+- myzmanim.com degrees/explanations — <https://www.myzmanim.com/read/degrees.aspx>
+- Chabad.org "About Our Zmanim Calculations" — <https://www.chabad.org/library/article_cdo/aid/3209349>
+
+## `definitions.ts` — the single source of truth
+
+`src/lib/zmanim/definitions.ts` binds each displayed zman to an exact `kosher-zmanim` method. Each entry is `{ key, base, method, category, order, erevOnly? }`:
+
+- `key` — stable id used to look up the name/shita/description in the message catalogs (`zmanim.names` / `zmanim.shitot` / `zmanim.descriptions`).
+- `base` — groups opinions of the same zman (e.g. `alos`, `misheyakir`, `sofZmanShma`, `sofZmanTfila`, `tzais`).
+- `method` — the `ComplexZmanimCalendar` method to call.
+- `category` — day-part for sectioning (`dawn`/`morning`/`midday`/`afternoon`/`evening`).
+- `order` — display order (strictly increasing).
+- `erevOnly` — `candleLighting` only.
+
+`definitions.test.ts` enforces the invariants: every `method` exists on the calendar prototype, keys are unique, `order` is strictly increasing, and the **exact `key → method` mapping is locked** — so a zman can never silently start being shown under the wrong name or computed by the wrong method. If you add/rename a zman, update the locked mapping test deliberately.
+
+## `calculator.ts` — timezone-correct computation
+
+`computeZmanim({ lat, lng, date, elevation = 0, timeZoneId?, candleLightingOffset = 18 })` returns `{ key, time, erevOnly }[]`.
+
+**The critical detail:** the calendar day is established by constructing *noon in the target zone from date components*:
+
+```ts
+const localNoon = DateTime.fromObject(
+  { year, month, day, hour: 12 },
+  { zone: timeZoneId },
+);
+```
+
+Do **not** `setZone()` an existing instant to get the day — that shifts the calendar day across timezone/DST boundaries and produces times for the wrong day. `kosher-zmanim` returns each result as a UTC `DateTime`, which is then converted with `.setZone(timeZoneId)` for display. A golden test (validated to the second against Hebcal across Jerusalem, Brooklyn, London, Buenos Aires, LA) guards this, alongside invariant sweeps (chronological ordering over a lat/lng/date grid) and edge cases (polar day/night, DST, elevation, offset).
+
+`candleLighting` is computed for **every** day (sunset − offset). It is only meaningful on Erev Shabbat / Erev Yom Tov; callers must filter it (the panel's times strip and `NextZman` both gate it on "erev").
+
+## `groups.ts` — display grouping
+
+`buildZmanimGroups(zmanim, translators)` produces a two-level structure:
+
+1. by `category` (day-part) → `ZmanGroup`
+2. within a group, by `base` → `ZmanBaseGroup` with `rows: ZmanRow[]` (one per shita/opinion)
+
+Each base's visible caption is `baseDescriptions[base]` when there are multiple opinions, or the single row's `descriptions[key]` when there's one. The **per-opinion** detail (`descriptions[key]`) is shown behind the info popover, not inline (see `ShitaInfo`).
+
+## Calendar classification (`day-info.ts`, `day-events.ts`)
+
+- `getDayInfo(date, formatter?, locale, inIsrael)` → category, holiday label, `yomTovIndex`, `dayOfChanukah`, `isRoshChodesh`, `isShabbos`, `parsha`, `weekParsha`, `omer`, `isShabbosMevorchim`, Hebrew date.
+- `classify()` precedence matters because `isYomTov()` is broad. **Chanukah is checked first and classified as `weekday`** (it's a minor festival; `isYomTov()` reports it as a Yom Tov). Order: chanukah → cholHamoed → erevYomTov → yomTov → taanis → roshChodesh → shabbos → weekday.
+- `getDayEvents(date, times, inIsrael)` → candle lighting / havdalah / fast start / fast end. It uses **`isYomTovAssurBemelacha()`** (work-prohibited), NOT `isYomTov()`, to decide what's a "rest day." Tisha B'Av onset shows on its eve; Yom Kippur's end is havdalah (no duplicate nightfall).
+
+### Israel vs diaspora
+
+`location.inIsrael` (`tz === 'Asia/Jerusalem'`) is threaded into `getDayInfo`/`getDayEvents` via `jc.setInIsrael(...)`. It changes the **parsha schedule** (Israel and the diaspora diverge for several weeks after a festival) and **1- vs 2-day Yom Tov**. Persisted localStorage locations that predate the `inIsrael` field are backfilled.
+
+### Week parsha
+
+`kosher-zmanim`'s `getUpcomingParsha()` throws in 0.9, so this week's parsha (the upcoming Shabbat's, shown on weekdays too) is computed by walking forward to the coming Saturday and reading that day's parsha — with `inIsrael` applied so it matches the location's schedule.
+
+## Description accuracy notes
+
+The descriptions were rewritten to match authoritative sources. Watch these when editing:
+
+- **Alos 72 minutes** is a fixed 72 min before sunrise (4 mil × 18 min; Rambam/Rishonim). It is **not** the Magen Avraham's figure — the MGA is the authority who *uses* an alos-72 day for proportional-hour zmanim (sof zman shma/tefila).
+- **Degree-based zmanim** (alos 16.1°, misheyakir 11.5/11/10.2°, tzeis 8.5°/5.95°): the depression angle is the real, location-independent definition. The "≈ X min before sunrise/after sunset" figure is only the **Jerusalem-equinox anchor** used to derive the angle and **varies by latitude and season** — keep the "in Jerusalem near the equinox; varies by place and season" qualifier.
+- **Tzeis 8.5°** = "three small stars" (per KosherJava's Ohr Meir), a slightly stringent nightfall. **Tzeis 5.95°** = the Geonim / Baal HaTanya early, lenient nightfall (used by some to end rabbinic fasts) — do not label it "small stars."
+- **Sof zman Shma/Tefila**: end of the 3rd / 4th proportional (`sha'ah zmanis`) hour. GRA measures the day sunrise→sunset; MGA measures alos(72)→tzeis(72), giving an earlier deadline.
+- **Vatikin**: complete Shema *just before* sunrise and begin the Amidah *at* netz.
+
+## Translations
+
+Terminology is unified with the companion `zmanim_bot` (transliterated zman names; readable opinion labels). Only **Russian** holiday names are overridden (`holidays-ru.ts`, keyed by `kosher-zmanim`'s `getYomTovIndex()`); Hebrew and English holiday and parsha names come from the library's `HebrewDateFormatter`. The visible caption (`baseDescriptions`) should stay halachically accurate; the per-opinion `descriptions` carry the degree/attribution detail.


### PR DESCRIPTION
Adds a documentation set to ease future work:

- **`CLAUDE.md`** — agent/contributor guide: commands, stack & version gotchas (Next 16 `proxy.ts`, React Compiler rules, next-intl v4 messages), architecture map, critical correctness rules, UI/responsive + accessibility conventions, i18n, deployment, and the no-attribution rule.
- **`docs/architecture.md`** — layering, state/hydration strategy, rendering & routes, the zmanim display pipeline, fixed-viewport calendar + compact fallback, color system, accessibility, i18n, keyless geo.
- **`docs/zmanim.md`** — the safety-critical domain: `definitions.ts` locked mapping, timezone-correct calculator, grouping, calendar classification (Israel vs diaspora, week-parsha workaround), and description-accuracy notes with sources.
- **`docs/deployment.md`** — image-only CI, server setup, GHCR auth, optional `.env`, and the cross-platform lockfile requirement.
- **README** — fixed the stale CI/CD section (SSH auto-deploy was removed) and linked the docs; ignore `/.idea/`.

Docs only — no code changes.