### PR TITLE
fix(calendar): use the full screen width and never clip cell content

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -18,7 +18,7 @@ import { ZmanimPanel } from '@/components/zmanim/zmanim-panel';
 
 function AppSkeleton() {
   return (
-    <div className="mx-auto flex h-full w-full max-w-6xl flex-col px-4 py-3 2xl:max-w-[2200px]">
+    <div className="mx-auto flex h-full w-full max-w-[2200px] flex-col px-4 py-3">
       <Skeleton className="mb-3 h-9 w-48 shrink-0" />
       <div className="flex min-h-0 flex-1 flex-col gap-4 lg:flex-row">
         <Skeleton className="min-h-0 flex-1 lg:flex-[2] 2xl:flex-[3]" />
@@ -65,7 +65,7 @@ export function App({ initialLocation }: { initialLocation?: AppLocation }) {
           />
           <main className="flex-1 lg:min-h-0">
             {mounted ? (
-              <div className="mx-auto flex w-full max-w-6xl flex-col px-4 py-3 lg:h-full 2xl:max-w-[2200px]">
+              <div className="mx-auto flex w-full max-w-[2200px] flex-col px-4 py-3 lg:h-full">
                 <div className="flex flex-1 flex-col gap-4 lg:min-h-0 lg:flex-row">
                   <div className="flex flex-col gap-2 lg:min-h-0 lg:flex-[2] 2xl:flex-[3]">
                     <CalendarView />

--- a/src/components/calendar/calendar-day.tsx
+++ b/src/components/calendar/calendar-day.tsx
@@ -76,10 +76,13 @@ export function CalendarDay({
 
   // Shrink the content to fit a short row instead of clipping it. `zoom` scales
   // the whole subtree (text, icons, gaps) and — unlike `transform` — affects
-  // layout, so the cell's `overflow-hidden` respects the smaller size. The width
-  // is pre-inflated by 1/scale so the zoomed content still fills the cell.
-  const fitStyle: CSSProperties | undefined =
-    scale < 1 ? { zoom: scale, width: `${(100 / scale).toFixed(3)}%` } : undefined;
+  // layout, so the cell's `overflow-hidden` respects the smaller size. With
+  // standardized `zoom` the element's own percentage width still resolves in
+  // the parent's (unzoomed) space, so the default 100% width already fills the
+  // cell and the children simply get 1/scale more room inside — do NOT
+  // pre-inflate the width, or the wrapper overflows the cell and its right
+  // edge gets clipped.
+  const fitStyle: CSSProperties | undefined = scale < 1 ? { zoom: scale } : undefined;
 
   return (
     <button
@@ -103,7 +106,7 @@ export function CalendarDay({
         isSelected && 'ring-day-selected ring-2 ring-inset',
       )}
     >
-      <div className="flex flex-col gap-0.5" style={fitStyle}>
+      <div data-day-content className="flex flex-col gap-0.5" style={fitStyle}>
         <div className="flex items-baseline justify-between gap-1">
         <span
           className={cn(
@@ -134,11 +137,13 @@ export function CalendarDay({
         </div>
       )}
 
-      {/* Medium + full: the significant-day label. */}
+      {/* Medium + full: the significant-day label. Long names wrap (up to two
+          lines) rather than clip — the grid's fit measurement absorbs the
+          extra line. */}
       {chipLabel && showLabels && (
         <span
           className={cn(
-            'truncate rounded px-1 text-[0.6875rem] leading-tight font-medium text-[color:var(--day-label)]',
+            'line-clamp-2 rounded px-1 text-[0.6875rem] leading-tight font-medium text-[color:var(--day-label)]',
             categoryChipClass(chipCategory),
           )}
           title={chipLabel}
@@ -166,22 +171,27 @@ export function CalendarDay({
         </div>
       )}
 
-      {/* Full only: the omer count. */}
+      {/* Full only: the omer count. Wraps to a second line instead of clipping
+          (`text-overflow` doesn't apply to flex containers, so `truncate` here
+          used to cut the text with no ellipsis at all). */}
       {info.omer > 0 && showExtras && (
         <span
-          className="text-muted-foreground flex items-center gap-1 truncate text-[0.6875rem]"
+          className="text-muted-foreground flex items-start gap-1 text-[0.6875rem] leading-tight"
           title={tPanel('omer', { day: info.omer })}
         >
-          <Wheat className="size-3 shrink-0" />
-          {tPanel('omer', { day: info.omer })}
+          <Wheat className="mt-px size-3 shrink-0" />
+          <span className="line-clamp-2 min-w-0">{tPanel('omer', { day: info.omer })}</span>
         </span>
       )}
 
       {/* Full only: the weekly parsha. */}
       {info.parsha && showExtras && (
-        <span className="text-muted-foreground flex items-center gap-1 truncate text-[0.6875rem]" title={info.parsha}>
-          <BookOpen className="size-3 shrink-0" />
-          {info.parsha}
+        <span
+          className="text-muted-foreground flex items-start gap-1 text-[0.6875rem] leading-tight"
+          title={info.parsha}
+        >
+          <BookOpen className="mt-px size-3 shrink-0" />
+          <span className="line-clamp-2 min-w-0">{info.parsha}</span>
         </span>
       )}
       </div>

--- a/src/components/calendar/calendar-grid.tsx
+++ b/src/components/calendar/calendar-grid.tsx
@@ -20,8 +20,10 @@ function weekdayHeaders(locale: string): string[] {
 // Cell-size thresholds (in rem, so they track the accessibility text scale).
 const MEDIUM_MIN_WIDTH_REM = 4; // narrower than this only a number + dot fits
 const FULL_MIN_WIDTH_REM = 6; // narrower than this the omer/parsha lines don't fit
-// Content height each tier needs at scale 1 (measured against the busiest months).
-const CONTENT_NEED_REM: Record<CellDensity, number> = { full: 5.4, medium: 3.7, compact: 2.4 };
+// First-pass estimate of each tier's content height. Only used until a tier has
+// been rendered once — after that its real height is measured from the DOM
+// (which, unlike a constant, accounts for wrapped labels and the locale).
+const ESTIMATED_NEED_REM: Record<CellDensity, number> = { full: 5.4, medium: 3.7, compact: 2.4 };
 const TIER_ORDER: CellDensity[] = ['full', 'medium', 'compact'];
 const MIN_SCALE = 0.72; // don't shrink text past this before dropping a tier
 
@@ -31,21 +33,35 @@ interface CellFit {
 }
 
 /**
- * Decide, from the *measured* cell size, how much each cell shows and how much to
- * shrink it so it fits without clipping:
+ * Decide, from the measured cell size and content, how much each cell shows and
+ * how much to shrink it so it fits without clipping:
  *  · Width picks the base tier (compact → medium → full) — horizontal room.
  *  · In the fixed-viewport (lg+) layout the rows are a height-constrained `1fr`,
- *    so the content is scaled down (via `zoom`) to fit that height. Only if it
- *    would have to shrink past {@link MIN_SCALE} does the tier step down.
+ *    so the content is scaled down (via `zoom`) to fit the tallest cell's real
+ *    content. Only if it would have to shrink past {@link MIN_SCALE} does the
+ *    tier step down.
  * Below lg the grid is content-sized, so height never constrains (scale stays 1).
  *
- * Both dimensions are viewport-driven (column width and the `1fr` track), never
- * content-driven, so changing tier/scale can't change the measurement — no
- * oscillation. Measuring in rem folds in the accessibility text scaling; the
- * `fontScale` dep re-measures when the scale changes but the element size doesn't.
+ * The content height is measured with zoom/width reset to their natural values,
+ * so the measurement is independent of the currently applied scale — applying a
+ * new fit can't change the next measurement, and there's no oscillation. Tiers
+ * that haven't been rendered yet use {@link ESTIMATED_NEED_REM}; choosing one
+ * re-renders, which re-runs the effect (`fit.density` dep) and measures it for
+ * real. Measuring in rem folds in the accessibility text scaling; the
+ * `fontScale` dep re-measures when the scale changes but the element size
+ * doesn't, and the `contentKey` dep re-measures when the month's content
+ * changes without the grid resizing.
  */
-function useCellFit(gridRef: RefObject<HTMLDivElement | null>, fontScale: string): CellFit {
+function useCellFit(gridRef: RefObject<HTMLDivElement | null>, fontScale: string, contentKey: string): CellFit {
   const [fit, setFit] = useState<CellFit>({ density: 'full', scale: 1 });
+  // Measured natural content height (rem) per rendered tier, valid for one
+  // content + cell-width + font-scale combination.
+  const measuredRef = useRef<{ key: string; width: number; need: Partial<Record<CellDensity, number>> }>({
+    key: '',
+    width: 0,
+    need: {},
+  });
+  const rendered = fit.density;
   useEffect(() => {
     const el = gridRef.current;
     if (!el || typeof ResizeObserver === 'undefined') return;
@@ -55,25 +71,57 @@ function useCellFit(gridRef: RefObject<HTMLDivElement | null>, fontScale: string
       if (!cell || cell.clientWidth === 0) return;
       const rem = parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
       const w = cell.clientWidth / rem;
-      let density: CellDensity = w < MEDIUM_MIN_WIDTH_REM ? 'compact' : w < FULL_MIN_WIDTH_REM ? 'medium' : 'full';
-      let scale = 1;
-      if (window.matchMedia('(min-width: 1024px)').matches) {
-        const h = cell.clientHeight / rem;
-        // Shrink to fit the row; step the tier down only when we'd shrink too far.
-        for (let i = TIER_ORDER.indexOf(density); i < TIER_ORDER.length; i++) {
-          density = TIER_ORDER[i];
-          scale = h / CONTENT_NEED_REM[density];
-          if (scale >= MIN_SCALE || i === TIER_ORDER.length - 1) break;
+      const widthTier: CellDensity =
+        w < MEDIUM_MIN_WIDTH_REM ? 'compact' : w < FULL_MIN_WIDTH_REM ? 'medium' : 'full';
+
+      if (!window.matchMedia('(min-width: 1024px)').matches) {
+        setFit((prev) => (prev.density === widthTier && prev.scale === 1 ? prev : { density: widthTier, scale: 1 }));
+        return;
+      }
+
+      const cache = measuredRef.current;
+      const cacheKey = `${contentKey}|${fontScale}`;
+      if (cache.key !== cacheKey || Math.abs(cache.width - w) > 0.01) {
+        cache.key = cacheKey;
+        cache.width = w;
+        cache.need = {};
+      }
+
+      // Natural height of the tallest cell's content for the tier currently
+      // rendered. zoom is reset during the read so the result doesn't depend
+      // on the currently applied scale. (Wrapping at natural width is never
+      // looser than at the zoomed width, so this can only overestimate —
+      // content never clips.)
+      const wrappers = Array.from(el.querySelectorAll<HTMLElement>('[data-day-content]'));
+      const saved = wrappers.map((n) => n.style.getPropertyValue('zoom'));
+      for (const n of wrappers) n.style.setProperty('zoom', '1');
+      let needPx = 0;
+      for (const n of wrappers) needPx = Math.max(needPx, n.offsetHeight);
+      wrappers.forEach((n, i) => n.style.setProperty('zoom', saved[i]));
+      cache.need[rendered] = needPx / rem;
+
+      const cellStyle = getComputedStyle(cell);
+      const availRem =
+        (cell.clientHeight - parseFloat(cellStyle.paddingTop) - parseFloat(cellStyle.paddingBottom) - 1) / rem;
+
+      // Densest tier (from the width baseline down) that fits the row without
+      // shrinking past MIN_SCALE.
+      let next: CellFit = { density: 'compact', scale: MIN_SCALE };
+      for (let i = TIER_ORDER.indexOf(widthTier); i < TIER_ORDER.length; i++) {
+        const tier = TIER_ORDER[i];
+        const scale = Math.min(1, availRem / (cache.need[tier] ?? ESTIMATED_NEED_REM[tier]));
+        if (scale >= MIN_SCALE || i === TIER_ORDER.length - 1) {
+          next = { density: tier, scale: Math.max(MIN_SCALE, scale) };
+          break;
         }
-        scale = Math.max(MIN_SCALE, Math.min(1, scale));
       }
       setFit((prev) =>
-        prev.density === density && Math.abs(prev.scale - scale) < 0.01 ? prev : { density, scale },
+        prev.density === next.density && Math.abs(prev.scale - next.scale) < 0.01 ? prev : next,
       );
     });
     ro.observe(el);
     return () => ro.disconnect();
-  }, [gridRef, fontScale]);
+  }, [gridRef, fontScale, contentKey, rendered]);
   return fit;
 }
 
@@ -84,10 +132,21 @@ export function CalendarGrid() {
   const locale = useLocale();
   const tCat = useTranslations('categories');
 
-  // Each cell shows compact / medium / full detail — and shrinks to fit — based on
-  // its measured size.
+  // Each cell shows compact / medium / full detail — and shrinks to fit — based
+  // on its measured size and content. Everything that changes what the cells
+  // render (and so their measured height) is folded into the key.
   const gridRef = useRef<HTMLDivElement>(null);
-  const { density, scale } = useCellFit(gridRef, fontScale);
+  const contentKey = [
+    monthDate.toISODate(),
+    mode,
+    locale,
+    location.lat,
+    location.lng,
+    location.timeZoneId,
+    candleLightingOffset,
+    havdalahOpinion,
+  ].join('|');
+  const { density, scale } = useCellFit(gridRef, fontScale, contentKey);
 
   const headers = weekdayHeaders(locale);
 

--- a/src/components/calendar/calendar-grid.tsx
+++ b/src/components/calendar/calendar-grid.tsx
@@ -26,6 +26,10 @@ const FULL_MIN_WIDTH_REM = 6; // narrower than this the omer/parsha lines don't 
 const ESTIMATED_NEED_REM: Record<CellDensity, number> = { full: 5.4, medium: 3.7, compact: 2.4 };
 const TIER_ORDER: CellDensity[] = ['full', 'medium', 'compact'];
 const MIN_SCALE = 0.72; // don't shrink text past this before dropping a tier
+// Safety slack against sub-pixel rounding of the `1fr` row tracks and the
+// applied zoom — without it an exact-fit cell can clip its last line by a
+// hairline.
+const FIT_SLACK_PX = 1;
 
 interface CellFit {
   density: CellDensity;
@@ -91,18 +95,23 @@ function useCellFit(gridRef: RefObject<HTMLDivElement | null>, fontScale: string
       // rendered. zoom is reset during the read so the result doesn't depend
       // on the currently applied scale. (Wrapping at natural width is never
       // looser than at the zoomed width, so this can only overestimate —
-      // content never clips.)
-      const wrappers = Array.from(el.querySelectorAll<HTMLElement>('[data-day-content]'));
-      const saved = wrappers.map((n) => n.style.getPropertyValue('zoom'));
-      for (const n of wrappers) n.style.setProperty('zoom', '1');
-      let needPx = 0;
-      for (const n of wrappers) needPx = Math.max(needPx, n.offsetHeight);
-      wrappers.forEach((n, i) => n.style.setProperty('zoom', saved[i]));
-      cache.need[rendered] = needPx / rem;
+      // content never clips.) The cache is invalidated on every input that
+      // could change the result (content, font scale, cell width, tier), so a
+      // hit — e.g. a height-only resize — skips the whole write/read pass.
+      if (cache.need[rendered] === undefined) {
+        const wrappers = Array.from(el.querySelectorAll<HTMLElement>('[data-day-content]'));
+        const saved = wrappers.map((n) => n.style.getPropertyValue('zoom'));
+        for (const n of wrappers) n.style.setProperty('zoom', '1');
+        let needPx = 0;
+        for (const n of wrappers) needPx = Math.max(needPx, n.offsetHeight);
+        wrappers.forEach((n, i) => n.style.setProperty('zoom', saved[i]));
+        cache.need[rendered] = needPx / rem;
+      }
 
       const cellStyle = getComputedStyle(cell);
       const availRem =
-        (cell.clientHeight - parseFloat(cellStyle.paddingTop) - parseFloat(cellStyle.paddingBottom) - 1) / rem;
+        (cell.clientHeight - parseFloat(cellStyle.paddingTop) - parseFloat(cellStyle.paddingBottom) - FIT_SLACK_PX) /
+        rem;
 
       // Densest tier (from the width baseline down) that fits the row without
       // shrinking past MIN_SCALE.

--- a/src/components/layout/site-footer.tsx
+++ b/src/components/layout/site-footer.tsx
@@ -61,7 +61,7 @@ export function SiteFooter() {
   const t = useTranslations('footer');
   return (
     <footer className="text-muted-foreground shrink-0 border-t py-2.5 text-center text-[0.6875rem] leading-tight">
-      <div className="mx-auto flex max-w-6xl flex-wrap items-center justify-center gap-x-2 gap-y-1 px-4 2xl:max-w-[2200px]">
+      <div className="mx-auto flex max-w-[2200px] flex-wrap items-center justify-center gap-x-2 gap-y-1 px-4">
         <span className="inline-flex items-center gap-1.5">
           <span>{t('madeBy')}</span>
           <span className="inline-flex items-center gap-1.5">

--- a/src/components/layout/site-header.tsx
+++ b/src/components/layout/site-header.tsx
@@ -10,7 +10,7 @@ export function SiteHeader({ right }: { right?: ReactNode }) {
   const t = useTranslations();
   return (
     <header className="bg-card/80 supports-[backdrop-filter]:bg-card/60 sticky top-0 z-30 shrink-0 border-b backdrop-blur">
-      <div className="mx-auto flex h-14 w-full max-w-6xl items-center justify-between gap-2 px-4 2xl:max-w-[2200px]">
+      <div className="mx-auto flex h-14 w-full max-w-[2200px] items-center justify-between gap-2 px-4">
         <Link href="/" className="flex items-center gap-2">
           <Sunrise className="text-primary size-6" />
           <span className="text-lg font-semibold tracking-tight">{t('brand')}</span>


### PR DESCRIPTION
## Problem

On laptop screens the month view wasted large side margins, and calendar cells trimmed their content — omer/date text was cut at the right edge with no ellipsis, and in busy months (e.g. May 2027 in Russian) the bottom line of a cell was clipped vertically.

## Changes

**Layout width** — the shell, header and footer were capped at `max-w-6xl` (1152px) until the `2xl` breakpoint (1536px), which a ~1512px MacBook viewport never reaches. The width is now fluid up to 2200px.

**Cell fitting** — three separate clipping causes fixed:

- The zoomed cell-content wrapper pre-inflated its width by `1/scale`; with standardized CSS `zoom` the element's own percentage width resolves in the parent's unzoomed space, so the wrapper overflowed the cell and its right edge was silently clipped. The inflation is removed.
- The shrink factor was derived from a hardcoded "busiest month" content-height estimate that long locales exceed, cutting the last line of busy cells. The grid now measures the real tallest cell (zoom reset during the read, so the measurement is scale-independent and can't oscillate), caches it per density tier, and re-measures on month/locale/location/font-scale changes — which also fixes stale scaling when the week count changes without a grid resize.
- Omer/parsha rows used `truncate` on a flex container, where `text-overflow` doesn't apply — text was cut with no ellipsis. Holiday chips, omer and parsha now wrap up to two lines instead of clipping, and the measured-height scaling absorbs the extra line.

## Verification

- Verified in Chrome at 1512×860 and 1512×690 (ru locale, Petah Tiqva, May 2027 and Tishrei 2026): every label renders in full, including the previously-cut parsha lines; clean console.
- At 1060px wide, long chips ("Холь а-Моэд Песах") wrap to two full lines and the density tier steps down as designed; mobile (390px) rows grow to fit wrapped labels as before.
- `lint`, `typecheck`, and all 81 unit tests pass.