### PR TITLE
feat(calendar): rework significant-day colors and classification

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -49,10 +49,13 @@
 
   /* Calendar day-category colors (carried over from the original palette). */
   --color-day-yomtov: var(--day-yomtov);
+  --color-day-yomtov-cell: var(--day-yomtov-cell);
   --color-day-cholhamoed: var(--day-cholhamoed);
   --color-day-chanukah: var(--day-chanukah);
   --color-day-erev: var(--day-erev);
   --color-day-taanis: var(--day-taanis);
+  --color-day-holiday: var(--day-holiday);
+  --color-day-isruchag: var(--day-isruchag);
   --color-day-roshchodesh: var(--day-roshchodesh);
   --color-day-shabbos: var(--day-shabbos);
   --color-day-label: var(--day-label);
@@ -93,13 +96,19 @@
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
 
-  /* Holiday / significant-day tints (light). */
-  --day-yomtov: #edbdd4;
-  --day-cholhamoed: #f8e6ef;
+  /* Holiday / significant-day tints (light). One pastel family — hues carry the
+     meaning, the weight stays uniform so a busy month (Tishrei) reads calm.
+     Yom Tov is the deepest chip and the only category that also fills its cell,
+     with a whisper of the same rose (matched to the Shabbat tint's weight). */
+  --day-yomtov: #ecc0d5; /* rose — the strongest chip in the system */
+  --day-yomtov-cell: #f9edf3; /* the Yom Tov cell wash */
+  --day-cholhamoed: #f6dfea; /* lighter rose than Yom Tov */
   --day-chanukah: #92cfb0;
-  --day-erev: #fbeede;
-  --day-taanis: #dfe1ea;
-  --day-roshchodesh: #c6def4;
+  --day-erev: #f7eedd; /* soft sand */
+  --day-taanis: #e0e2ea;
+  --day-holiday: #f7efc3; /* soft butter — labeled minor holidays (Purim, Tu B'Av, …) */
+  --day-isruchag: #eaebef; /* light grey — quieter than the minor-holiday yellow */
+  --day-roshchodesh: #d4e4f5;
   --day-shabbos: #f2f8fe;
   --day-label: #2c2d35;
   --day-selected: #2563eb;
@@ -138,13 +147,16 @@
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
 
-  /* Holiday / significant-day tints (dark, muted). */
-  --day-yomtov: oklch(0.45 0.09 350);
-  --day-cholhamoed: oklch(0.36 0.05 350);
+  /* Holiday / significant-day tints (dark, muted — same family as light). */
+  --day-yomtov: oklch(0.42 0.08 350); /* rose — the strongest chip in the system */
+  --day-yomtov-cell: oklch(0.25 0.02 350); /* the Yom Tov cell wash */
+  --day-cholhamoed: oklch(0.33 0.045 350); /* lighter rose than Yom Tov */
   --day-chanukah: oklch(0.45 0.08 160);
-  --day-erev: oklch(0.42 0.05 70);
+  --day-erev: oklch(0.36 0.035 80); /* soft sand */
   --day-taanis: oklch(0.38 0.02 265);
-  --day-roshchodesh: oklch(0.45 0.07 245);
+  --day-holiday: oklch(0.4 0.05 95); /* soft butter — labeled minor holidays */
+  --day-isruchag: oklch(0.35 0.01 265); /* muted grey — quieter than the minor-holiday yellow */
+  --day-roshchodesh: oklch(0.42 0.055 245);
   --day-shabbos: oklch(0.32 0.03 245);
   --day-label: oklch(0.985 0 0);
   --day-selected: #3b82f6;

--- a/src/components/calendar/calendar-day.tsx
+++ b/src/components/calendar/calendar-day.tsx
@@ -92,7 +92,9 @@ export function CalendarDay({
       aria-pressed={isSelected}
       aria-current={isToday ? 'date' : undefined}
       className={cn(
-        'block h-full min-h-11 overflow-hidden p-1 text-start transition-colors sm:min-h-12',
+        // flex (not block): buttons vertically center their content, which made
+        // cells with less content sit lower than their row siblings.
+        'flex h-full min-h-11 flex-col overflow-hidden p-1 text-start transition-colors sm:min-h-12',
         'focus-visible:ring-day-selected focus-visible:ring-2 focus-visible:outline-none',
         // Base: the day's category tint (dimmed for out-of-month padding days).
         cellBackgroundClass(info.category, !inMonth),

--- a/src/components/calendar/day-style.ts
+++ b/src/components/calendar/day-style.ts
@@ -13,19 +13,21 @@ export type DayTone =
   | 'roshChodesh'
   | 'chanukah'
   | 'minor'
+  | 'isruChag'
   | 'shabbat'
   | 'omer'
   | 'mevorchim'
   | 'parsha';
 
 export const DAY_TONE: Record<DayTone, { chip: string; dot: string }> = {
-  festival: { chip: 'bg-pink-100 text-pink-700 dark:bg-pink-500/15 dark:text-pink-300', dot: 'bg-pink-500' },
-  cholHamoed: { chip: 'bg-pink-50 text-pink-600 dark:bg-pink-500/10 dark:text-pink-300', dot: 'bg-pink-300' },
+  festival: { chip: 'bg-pink-100 text-pink-800 dark:bg-pink-500/20 dark:text-pink-200', dot: 'bg-pink-500' },
+  cholHamoed: { chip: 'bg-pink-50 text-pink-700 dark:bg-pink-500/10 dark:text-pink-300', dot: 'bg-pink-300' },
   erev: { chip: 'bg-amber-100 text-amber-800 dark:bg-amber-500/15 dark:text-amber-300', dot: 'bg-amber-400' },
   fast: { chip: 'bg-slate-100 text-slate-700 dark:bg-slate-500/15 dark:text-slate-300', dot: 'bg-slate-400' },
   roshChodesh: { chip: 'bg-blue-100 text-blue-700 dark:bg-blue-500/15 dark:text-blue-300', dot: 'bg-blue-500' },
   chanukah: { chip: 'bg-amber-100 text-amber-800 dark:bg-amber-500/15 dark:text-amber-300', dot: 'bg-amber-500' },
-  minor: { chip: 'bg-primary/10 text-primary', dot: 'bg-primary' },
+  minor: { chip: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-500/15 dark:text-yellow-300', dot: 'bg-yellow-400' },
+  isruChag: { chip: 'bg-gray-100 text-gray-600 dark:bg-gray-500/15 dark:text-gray-300', dot: 'bg-gray-400' },
   shabbat: { chip: 'bg-sky-100 text-sky-700 dark:bg-sky-500/15 dark:text-sky-300', dot: 'bg-sky-500' },
   omer: { chip: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-300', dot: 'bg-emerald-500' },
   mevorchim: { chip: 'bg-violet-100 text-violet-700 dark:bg-violet-500/15 dark:text-violet-300', dot: 'bg-violet-500' },
@@ -46,14 +48,21 @@ export function significantTone(category: DayCategory, dayOfChanukah: number): D
       return 'fast';
     case 'roshChodesh':
       return 'roshChodesh';
+    case 'isruChag':
+      return 'isruChag';
     default:
       return 'minor'; // a labeled weekday: Purim, Tu BiShvat, Lag BaOmer (when not a Yom Tov), …
   }
 }
 
-/** Background tint for a calendar cell (subtle; only Shabbat gets a base tint). */
+/**
+ * Background tint for a calendar cell. Yom Tov is the only significant-day
+ * category whose whole cell is filled (a whisper of the Yom Tov rose under its
+ * full-strength chip); Shabbat keeps its subtle base tint.
+ */
 export function cellBackgroundClass(category: DayCategory, isOffRange: boolean): string {
   if (isOffRange) return 'bg-muted/40';
+  if (category === 'yomTov') return 'bg-day-yomtov-cell';
   if (category === 'shabbos') return 'bg-day-shabbos';
   return 'bg-card';
 }
@@ -67,7 +76,9 @@ export function categoryChipClass(category: DayCategory): string {
     taanis: 'bg-day-taanis',
     roshChodesh: 'bg-day-roshchodesh',
     shabbos: 'bg-day-shabbos',
-    weekday: 'bg-muted',
+    isruChag: 'bg-day-isruchag',
+    // A labeled weekday is a minor holiday (Purim, Tu B'Av, Chanukah, …).
+    weekday: 'bg-day-holiday',
   };
   return map[category];
 }

--- a/src/lib/calendar/day-info.test.ts
+++ b/src/lib/calendar/day-info.test.ts
@@ -12,6 +12,13 @@ describe('getDayInfo', () => {
     ['2024-10-12', 'yomTov', 'Yom Kippur'], // also a Shabbos + fast — yomTov wins
     ['2024-12-26', 'weekday', 'Chanukah 1'], // minor festival — neutral chip, not Yom Tov
     ['2024-07-23', 'taanis', 'Seventeenth of Tammuz'],
+    // Minor holidays: isYomTov() reports them, but work is permitted — they must
+    // classify as labeled weekdays (holiday tint), never as Yom Tov.
+    ['2026-03-03', 'weekday', 'Purim'],
+    ['2026-05-01', 'weekday', 'Pesach Sheni'],
+    ['2026-07-29', 'weekday', "Tu B'Av"],
+    ['2026-05-22', 'yomTov', 'Shavuos'], // work-prohibited — stays Yom Tov
+    ['2026-04-10', 'isruChag', 'Isru Chag'], // day after Pesach (diaspora) — neutral grey, not the holiday tint
   ])('classifies %s as %s (%s)', (iso, category, label) => {
     const info = getDayInfo(DateTime.fromISO(iso));
     expect(info.category).toBe(category);

--- a/src/lib/calendar/day-info.ts
+++ b/src/lib/calendar/day-info.ts
@@ -53,10 +53,16 @@ function classify(jc: JewishCalendar, isShabbos: boolean): DayCategory {
   if (jc.isChanukah()) return 'weekday';
   if (jc.isCholHamoed()) return 'cholHamoed';
   if (jc.isErevYomTov()) return 'erevYomTov';
-  if (jc.isYomTov()) return 'yomTov';
+  // Only work-prohibited days count as Yom Tov for coloring. The broad
+  // isYomTov() also reports minor holidays (Purim, Pesach Sheni, Tu B'Av, …),
+  // which must fall through to the labeled-weekday (minor holiday) tint.
+  if (jc.isYomTovAssurBemelacha()) return 'yomTov';
   if (jc.isTaanis()) return 'taanis';
   if (jc.isRoshChodesh()) return 'roshChodesh';
   if (isShabbos) return 'shabbos';
+  // Isru Chag is quieter than the other labeled weekdays (Purim & co.) — it
+  // gets a neutral grey rather than the holiday tint.
+  if (jc.getYomTovIndex() === JewishCalendar.ISRU_CHAG) return 'isruChag';
   return 'weekday';
 }
 

--- a/src/lib/calendar/types.ts
+++ b/src/lib/calendar/types.ts
@@ -10,6 +10,7 @@ export type DayCategory =
   | 'taanis'
   | 'roshChodesh'
   | 'shabbos'
+  | 'isruChag'
   | 'weekday';
 
 export interface MonthGridCell {


### PR DESCRIPTION
## Summary

- Classify only work-prohibited days (`isYomTovAssurBemelacha()`) as Yom Tov: the broad `isYomTov()` also reported minor holidays (Purim, Pesach Sheni, Tu B'Av), which were rendered in the Yom Tov color. Minor holidays now get their own tint, and Isru Chag a quieter, dedicated category. Pinned with new `day-info` test rows.
- Rework the day colors into one pastel family where hue carries the meaning:
  - **Yom Tov** — rose, the deepest chip, and the only category whose cell is filled (a subtle wash via a dedicated `--day-yomtov-cell` token, matched to the Shabbat tint's weight)
  - **Chol Hamoed** — lighter rose
  - **Erev Yom Tov** — soft sand
  - **Minor holidays** (Purim, Tu B'Av, Chanukah, …) — soft butter, replacing the old grey `bg-muted` chip
  - **Rosh Chodesh** — blue; **fasts / Isru Chag** — grey
  - Same family at muted lightness in dark mode; compact-view dots and day-panel chips follow via the shared tone map
- Top-align day-cell content: the cell `<button>` vertically centered its content, so cells with fewer lines sat lower than their row siblings and chips did not line up across a row.

## Testing

- `lint`, `typecheck`, `test` (86 passing, incl. new classification pins)
- Verified in the running app (light/dark, desktop/mobile widths) on the worst-case months: Tishrei 5787 (Sep 2026), Pesach + Chanukah 2026