### PR TITLE
feat(calendar): month view polish

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -104,7 +104,7 @@
   --day-yomtov-cell: #f9edf3; /* the Yom Tov cell wash */
   --day-cholhamoed: #f6dfea; /* lighter rose than Yom Tov */
   --day-chanukah: #92cfb0;
-  --day-erev: #f7eedd; /* soft sand */
+  --day-erev: #f9f3e7; /* soft sand — deliberately faint: erev is a lead-in, not the event */
   --day-taanis: #e0e2ea;
   --day-holiday: #f7efc3; /* soft butter — labeled minor holidays (Purim, Tu B'Av, …) */
   --day-isruchag: #eaebef; /* light grey — quieter than the minor-holiday yellow */
@@ -152,7 +152,7 @@
   --day-yomtov-cell: oklch(0.25 0.02 350); /* the Yom Tov cell wash */
   --day-cholhamoed: oklch(0.33 0.045 350); /* lighter rose than Yom Tov */
   --day-chanukah: oklch(0.45 0.08 160);
-  --day-erev: oklch(0.36 0.035 80); /* soft sand */
+  --day-erev: oklch(0.32 0.025 80); /* soft sand — deliberately faint: erev is a lead-in, not the event */
   --day-taanis: oklch(0.38 0.02 265);
   --day-holiday: oklch(0.4 0.05 95); /* soft butter — labeled minor holidays */
   --day-isruchag: oklch(0.35 0.01 265); /* muted grey — quieter than the minor-holiday yellow */

--- a/src/components/calendar/calendar-day.tsx
+++ b/src/components/calendar/calendar-day.tsx
@@ -6,7 +6,7 @@ import type { DateTime } from 'luxon';
 import type { ComponentType, CSSProperties } from 'react';
 
 import { CandleFlames } from '@/components/icons/candle-flames';
-import type { CalendarMode, DayEvent, DayEventType, DayInfo } from '@/lib/calendar';
+import type { CalendarMode, DayCategory, DayEvent, DayEventType, DayInfo } from '@/lib/calendar';
 import { formatTime } from '@/lib/format';
 import { cn } from '@/lib/utils';
 
@@ -30,11 +30,17 @@ const EVENT_META: Record<DayEventType, { Icon: ComponentType<{ className?: strin
  */
 export type CellDensity = 'compact' | 'medium' | 'full';
 
+/** A significant-day marker for a cell — a labeled chip in medium/full, a dot in compact. */
+export interface CellChip {
+  label: string;
+  category: DayCategory;
+}
+
 interface CalendarDayProps {
   date: DateTime;
   inMonth: boolean;
   info: DayInfo;
-  chipLabel: string | null;
+  chips: CellChip[];
   events: DayEvent[];
   mode: CalendarMode;
   locale: string;
@@ -50,7 +56,7 @@ export function CalendarDay({
   date,
   inMonth,
   info,
-  chipLabel,
+  chips,
   events,
   mode,
   locale,
@@ -68,8 +74,9 @@ export function CalendarDay({
       ? date.setLocale(locale).toLocaleString({ day: 'numeric', month: 'long' })
       : `${info.hebrewDayOfMonth} ${info.hebrewMonth}`;
 
-  // Rosh Chodesh days that aren't otherwise labeled still use the Rosh Chodesh tint.
-  const chipCategory = info.category === 'weekday' && info.isRoshChodesh ? 'roshChodesh' : info.category;
+  // The dot mirrors its chip's color; a Chanukah label keeps its Chanukah tone.
+  const chipTone = (chip: CellChip) =>
+    significantTone(chip.category, chip.category === 'weekday' ? info.dayOfChanukah : 0);
 
   const showLabels = density !== 'compact'; // medium + full
   const showExtras = density === 'full'; // omer + parsha
@@ -129,30 +136,35 @@ export function CalendarDay({
         <span className="text-muted-foreground truncate text-[0.625rem] leading-tight">{secondary}</span>
       )}
 
-      {/* Compact: a single dot marks a significant day. */}
-      {chipLabel && !showLabels && (
-        <div className="flex" aria-hidden>
-          <span
-            className={cn('size-1.5 shrink-0 rounded-full', DAY_TONE[significantTone(info.category, info.dayOfChanukah)].dot)}
-            title={chipLabel}
-          />
+      {/* Compact: a dot per significant-day marker. */}
+      {chips.length > 0 && !showLabels && (
+        <div className="flex gap-0.5" aria-hidden>
+          {chips.map((chip) => (
+            <span
+              key={chip.label}
+              className={cn('size-1.5 shrink-0 rounded-full', DAY_TONE[chipTone(chip)].dot)}
+              title={chip.label}
+            />
+          ))}
         </div>
       )}
 
-      {/* Medium + full: the significant-day label. Long names wrap (up to two
+      {/* Medium + full: the significant-day labels. Long names wrap (up to two
           lines) rather than clip — the grid's fit measurement absorbs the
           extra line. */}
-      {chipLabel && showLabels && (
-        <span
-          className={cn(
-            'line-clamp-2 rounded px-1 text-[0.6875rem] leading-tight font-medium text-[color:var(--day-label)]',
-            categoryChipClass(chipCategory),
-          )}
-          title={chipLabel}
-        >
-          {chipLabel}
-        </span>
-      )}
+      {showLabels &&
+        chips.map((chip) => (
+          <span
+            key={chip.label}
+            className={cn(
+              'line-clamp-2 rounded px-1 text-[0.6875rem] leading-tight font-medium text-[color:var(--day-label)]',
+              categoryChipClass(chip.category),
+            )}
+            title={chip.label}
+          >
+            {chip.label}
+          </span>
+        ))}
 
       {/* Medium + full: candle-lighting / havdalah / fast times. */}
       {events.length > 0 && showLabels && (

--- a/src/components/calendar/calendar-grid.tsx
+++ b/src/components/calendar/calendar-grid.tsx
@@ -9,7 +9,7 @@ import { useAppState } from '@/components/providers/app-state';
 import { buildMonthGrid, createHebrewFormatter, getDayEvents, getDayInfo, localizedHolidayLabel } from '@/lib/calendar';
 import { computeZmanim, havdalahTime } from '@/lib/zmanim';
 
-import { CalendarDay, type CellDensity } from './calendar-day';
+import { CalendarDay, type CellChip, type CellDensity } from './calendar-day';
 
 /** Sunday-first localized short weekday names. */
 function weekdayHeaders(locale: string): string[] {
@@ -167,7 +167,13 @@ export function CalendarGrid() {
   const days = grid.cells.map((cell) => {
     const info = getDayInfo(cell.date, formatter, locale, location.inIsrael);
     const label = localizedHolidayLabel(locale, info.label, info.yomTovIndex, info.dayOfChanukah);
-    const chipLabel = label ?? (info.isRoshChodesh ? tCat('roshChodesh') : null);
+    // A day can carry two markers (Chanukah on Rosh Chodesh) — show both rather
+    // than letting one win.
+    const chips: CellChip[] = [];
+    if (label) chips.push({ label, category: info.category });
+    if (info.isRoshChodesh && !(label && info.category === 'roshChodesh')) {
+      chips.push({ label: tCat('roshChodesh'), category: 'roshChodesh' });
+    }
 
     const zmanim = computeZmanim({
       lat: location.lat,
@@ -189,7 +195,7 @@ export function CalendarGrid() {
       location.inIsrael,
     );
 
-    return { cell, info, chipLabel, events };
+    return { cell, info, chips, events };
   });
 
   // Safe to call now() here: the app shell gates rendering until mounted, so
@@ -213,13 +219,13 @@ export function CalendarGrid() {
           {name}
         </div>
       ))}
-      {days.map(({ cell, info, chipLabel, events }) => (
+      {days.map(({ cell, info, chips, events }) => (
         <CalendarDay
           key={cell.date.toISODate()}
           date={cell.date}
           inMonth={cell.inMonth}
           info={info}
-          chipLabel={chipLabel}
+          chips={chips}
           events={events}
           mode={mode}
           locale={locale}

--- a/src/components/calendar/calendar-view.tsx
+++ b/src/components/calendar/calendar-view.tsx
@@ -24,11 +24,42 @@ function useMonthTitle(): string {
   return monthDate.setLocale(locale).toLocaleString({ month: 'long', year: 'numeric' });
 }
 
+/**
+ * The viewed month expressed in the *other* calendar system — the Hebrew
+ * month(s) a civil month spans, or the civil month(s) a Hebrew month spans.
+ * Years are repeated only when the span crosses a year boundary.
+ */
+function useAlternateMonths(): string {
+  const { monthDate, mode } = useAppState();
+  const locale = useLocale();
+
+  if (mode === 'hebrew') {
+    const jd = new JewishDate(monthDate);
+    jd.setJewishDayOfMonth(1);
+    const start = jd.getDate().setLocale(locale);
+    const end = start.plus({ days: jd.getDaysInJewishMonth() - 1 });
+    if (start.month === end.month) return start.toLocaleString({ month: 'long', year: 'numeric' });
+    const endLabel = end.toLocaleString({ month: 'long', year: 'numeric' });
+    if (start.year === end.year) return `${start.toLocaleString({ month: 'long' })} – ${endLabel}`;
+    return `${start.toLocaleString({ month: 'long', year: 'numeric' })} – ${endLabel}`;
+  }
+
+  const fmt = createHebrewFormatter(locale);
+  const start = new JewishDate(monthDate.startOf('month'));
+  const end = new JewishDate(monthDate.endOf('month').startOf('day'));
+  if (start.getJewishMonth() === end.getJewishMonth()) return `${fmt.formatMonth(start)} ${start.getJewishYear()}`;
+  if (start.getJewishYear() === end.getJewishYear()) {
+    return `${fmt.formatMonth(start)} – ${fmt.formatMonth(end)} ${end.getJewishYear()}`;
+  }
+  return `${fmt.formatMonth(start)} ${start.getJewishYear()} – ${fmt.formatMonth(end)} ${end.getJewishYear()}`;
+}
+
 export function CalendarView() {
   const { monthDate, mode, setMode, setMonthDate, selectedDay, setSelectedDay } = useAppState();
   const t = useTranslations('calendar');
   const locale = useLocale();
   const title = useMonthTitle();
+  const alternateMonths = useAlternateMonths();
   const rtl = dirForLocale(locale) === 'rtl';
   const [pickerOpen, setPickerOpen] = useState(false);
 
@@ -59,10 +90,13 @@ export function CalendarView() {
           <PopoverTrigger asChild>
             <button
               type="button"
-              className="flex items-center gap-1.5 text-xl font-semibold tracking-tight capitalize hover:opacity-80 sm:text-2xl"
+              className="flex flex-wrap items-center gap-x-2 gap-y-0 text-xl font-semibold tracking-tight hover:opacity-80 sm:text-2xl"
             >
-              {title}
-              <ChevronDown className="size-4 opacity-50" />
+              <span className="flex items-center gap-1.5 capitalize">
+                {title}
+                <ChevronDown className="size-4 opacity-50" />
+              </span>
+              <span className="text-muted-foreground text-sm font-normal tracking-normal">{alternateMonths}</span>
             </button>
           </PopoverTrigger>
           <PopoverContent align="start" className="w-auto space-y-2">

--- a/src/components/calendar/calendar-view.tsx
+++ b/src/components/calendar/calendar-view.tsx
@@ -11,7 +11,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
-import { createHebrewFormatter, monthAnchor, nextMonth, nextYear, prevMonth, prevYear } from '@/lib/calendar';
+import { createHebrewFormatter, jewishToLocalDay, monthAnchor, nextMonth, nextYear, prevMonth, prevYear } from '@/lib/calendar';
 import { dirForLocale } from '@/i18n/routing';
 
 function useMonthTitle(): string {
@@ -36,7 +36,9 @@ function useAlternateMonths(): string {
   if (mode === 'hebrew') {
     const jd = new JewishDate(monthDate);
     jd.setJewishDayOfMonth(1);
-    const start = jd.getDate().setLocale(locale);
+    // jewishToLocalDay severs kosher-zmanim's bundled Luxon — its DateTimes
+    // don't interoperate safely with this app's Luxon instance.
+    const start = jewishToLocalDay(jd).setLocale(locale);
     const end = start.plus({ days: jd.getDaysInJewishMonth() - 1 });
     if (start.month === end.month) return start.toLocaleString({ month: 'long', year: 'numeric' });
     const endLabel = end.toLocaleString({ month: 'long', year: 'numeric' });

--- a/src/components/calendar/day-style.ts
+++ b/src/components/calendar/day-style.ts
@@ -22,7 +22,7 @@ export type DayTone =
 export const DAY_TONE: Record<DayTone, { chip: string; dot: string }> = {
   festival: { chip: 'bg-pink-100 text-pink-800 dark:bg-pink-500/20 dark:text-pink-200', dot: 'bg-pink-500' },
   cholHamoed: { chip: 'bg-pink-50 text-pink-700 dark:bg-pink-500/10 dark:text-pink-300', dot: 'bg-pink-300' },
-  erev: { chip: 'bg-amber-100 text-amber-800 dark:bg-amber-500/15 dark:text-amber-300', dot: 'bg-amber-400' },
+  erev: { chip: 'bg-amber-50 text-amber-800 dark:bg-amber-500/10 dark:text-amber-300', dot: 'bg-amber-300' },
   fast: { chip: 'bg-slate-100 text-slate-700 dark:bg-slate-500/15 dark:text-slate-300', dot: 'bg-slate-400' },
   roshChodesh: { chip: 'bg-blue-100 text-blue-700 dark:bg-blue-500/15 dark:text-blue-300', dot: 'bg-blue-500' },
   chanukah: { chip: 'bg-amber-100 text-amber-800 dark:bg-amber-500/15 dark:text-amber-300', dot: 'bg-amber-500' },

--- a/src/components/providers/app-state.tsx
+++ b/src/components/providers/app-state.tsx
@@ -165,8 +165,9 @@ export function AppStateProvider({
     }
   }, [location, candleLightingOffset, havdalahOpinion]);
 
-  // Restore calendar state (mode + selected day) from the URL on mount, so a
-  // shared link reopens the same day. Read post-mount to stay hydration-safe.
+  // Restore calendar state (mode + selected day + viewed month) from the URL on
+  // mount, so a shared link reopens the same view. Read post-mount to stay
+  // hydration-safe.
   useEffect(() => {
     const p = new URLSearchParams(window.location.search);
     const m = p.get('m');
@@ -174,13 +175,19 @@ export function AppStateProvider({
     const d = p.get('d');
     const dt = d ? DateTime.fromISO(d) : null;
     const restoredDay = dt?.isValid ? dt.startOf('day') : null;
-    if (!restoredMode && !restoredDay) return;
+    // The viewed month can differ from the selected day's month (the user
+    // browsed away) — it's carried separately so a reload keeps the view.
+    const v = p.get('v');
+    const vt = v ? DateTime.fromISO(v) : null;
+    const restoredView = vt?.isValid ? vt.startOf('day') : null;
+    if (!restoredMode && !restoredDay && !restoredView) return;
 
-    // Re-anchor the viewed month to the restored day (or today) in the restored
-    // mode, so a shared `?m=hebrew` link opens on the correct Hebrew month. On
-    // mount the mode state is still the 'gregorian' default, so fall back to it.
+    // Re-anchor the viewed month in the restored mode, so a shared `?m=hebrew`
+    // link opens on the correct Hebrew month. Older links have no `v` — fall
+    // back to the restored day (or today). On mount the mode state is still
+    // the 'gregorian' default, so fall back to it.
     const anchorMode = restoredMode ?? 'gregorian';
-    const anchorDay = restoredDay ?? DateTime.now().startOf('day');
+    const anchorDay = restoredView ?? restoredDay ?? DateTime.now().startOf('day');
     /* eslint-disable react-hooks/set-state-in-effect */
     if (restoredMode) setModeState(restoredMode);
     if (restoredDay) setSelectedDay(restoredDay);
@@ -188,14 +195,17 @@ export function AppStateProvider({
     /* eslint-enable react-hooks/set-state-in-effect */
   }, []);
 
-  // Reflect mode + selected day in the URL (without a navigation) for sharing.
+  // Reflect mode + selected day + viewed month in the URL (without a
+  // navigation) for sharing and reloads.
   useEffect(() => {
     const p = new URLSearchParams(window.location.search);
     p.set('m', mode);
     const iso = selectedDay.toISODate();
     if (iso) p.set('d', iso);
+    const view = monthDate.toISODate();
+    if (view) p.set('v', view);
     window.history.replaceState(null, '', `${window.location.pathname}?${p.toString()}`);
-  }, [mode, selectedDay]);
+  }, [mode, selectedDay, monthDate]);
 
   const toggleMode = () => setMode(mode === 'gregorian' ? 'hebrew' : 'gregorian');
 

--- a/src/lib/calendar/index.ts
+++ b/src/lib/calendar/index.ts
@@ -5,4 +5,5 @@ export { RU_MONTHS, RU_MONTHS_GENITIVE } from './months-ru';
 export { RU_PARSHIYOS } from './parshiyos-ru';
 export { buildMonthGrid, daysInActiveMonth, firstDayOfMonth } from './grid';
 export { monthAnchor, nextMonth, nextYear, prevMonth, prevYear, shiftMonth, shiftYear } from './navigation';
+export { jewishToLocalDay } from './jewish-date';
 export type { CalendarMode, DayCategory, DayInfo, MonthGrid, MonthGridCell } from './types';


### PR DESCRIPTION
## Summary

Four follow-ups to #42:

- **Softer Erev Yom Tov tint** — erev is a lead-in, not the event; its chip no longer competes with the holidays around it (both themes).
- **Both Chanukah and Rosh Chodesh markers** — on 30 Kislev / 1 Tevet the cell now shows two chips (and two dots in compact cells) instead of Rosh Chodesh swallowing the Chanukah label. Cells carry a list of markers now, so any future overlap renders too.
- **Alternate months next to the title** — a muted subtitle shows the viewed month's span in the other calendar system: "Декабрь 2026 · Кислев – Тевет 5787" in civil mode, "Тевет 5787 · декабрь 2026 – январь 2027" in Hebrew mode. Handles double-Adar and cross-year spans.
- **Viewed month persists in the URL** — browsing months away from the selected day and reloading used to snap back to the selected day's month. The view now travels in a `v` query param (re-anchored per mode); older links without it still anchor on the day.

## Testing

- `lint`, `typecheck`, `test` (86 passing)
- Verified in the running app: dual markers on Chanukah/Rosh Chodesh days (medium chips + compact dots), subtitle in civil/Hebrew modes incl. Adar I–II and cross-year spans, and month persistence across reloads with legacy-link fallback