### PR TITLE
fix(i18n): stale location label and console error on locale switch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "luxon": "^3.7.2",
         "next": "16.2.9",
         "next-intl": "^4.13.0",
-        "next-themes": "^0.4.6",
         "radix-ui": "^1.6.0",
         "react": "19.2.4",
         "react-dom": "19.2.4",
@@ -11269,16 +11268,6 @@
       "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/next-themes": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
-      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "luxon": "^3.7.2",
     "next": "16.2.9",
     "next-intl": "^4.13.0",
-    "next-themes": "^0.4.6",
     "radix-ui": "^1.6.0",
     "react": "19.2.4",
     "react-dom": "19.2.4",

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -8,9 +8,10 @@ import type { ReactNode } from 'react';
 import '../globals.css';
 
 import { AccessibilityProvider } from '@/components/providers/accessibility-provider';
-import { ThemeProvider, themeInitScript } from '@/components/providers/theme-provider';
+import { ThemeProvider } from '@/components/providers/theme-provider';
 import { dirForLocale, routing } from '@/i18n/routing';
 import { SITE_NAME, SITE_URL } from '@/lib/site';
+import { themeInitScript } from '@/lib/theme';
 
 const geistSans = Geist({ variable: '--font-geist-sans', subsets: ['latin'] });
 const geistMono = Geist_Mono({ variable: '--font-geist-mono', subsets: ['latin'] });

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -8,7 +8,7 @@ import type { ReactNode } from 'react';
 import '../globals.css';
 
 import { AccessibilityProvider } from '@/components/providers/accessibility-provider';
-import { ThemeProvider } from '@/components/providers/theme-provider';
+import { ThemeProvider, themeInitScript } from '@/components/providers/theme-provider';
 import { dirForLocale, routing } from '@/i18n/routing';
 import { SITE_NAME, SITE_URL } from '@/lib/site';
 
@@ -68,13 +68,21 @@ export default async function LocaleLayout({
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
       <body className="flex min-h-full flex-col">
-        {/* Apply saved accessibility prefs before paint to avoid a flash. */}
-        <script
+        {/* Apply the saved theme + accessibility prefs before paint to avoid
+            a flash. The scripts are emitted through a wrapper's innerHTML
+            rather than as React <script> elements: the HTML parser executes
+            them on the initial document, while client re-renders of this
+            layout (a locale switch remounts it) merely set innerHTML — inert
+            per spec — so React never client-renders a script tag (it warns
+            about those and wouldn't execute them; the theme and accessibility
+            providers re-apply the classes on mount anyway). */}
+        <div
+          hidden
           dangerouslySetInnerHTML={{
-            __html: `(function(){try{var p=JSON.parse(localStorage.getItem('zmanim:a11y:v1')||'{}');var e=document.documentElement;if(p.fontScale&&p.fontScale!=='default')e.classList.add('text-scale-'+p.fontScale);if(p.reduceMotion)e.classList.add('reduce-motion');if(p.highContrast)e.classList.add('high-contrast');}catch(e){}})();`,
+            __html: `<script>${themeInitScript}(function(){try{var p=JSON.parse(localStorage.getItem('zmanim:a11y:v1')||'{}');var e=document.documentElement;if(p.fontScale&&p.fontScale!=='default')e.classList.add('text-scale-'+p.fontScale);if(p.reduceMotion)e.classList.add('reduce-motion');if(p.highContrast)e.classList.add('high-contrast');}catch(e){}})();</script>`,
           }}
         />
-        <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+        <ThemeProvider>
           <AccessibilityProvider>
             <NextIntlClientProvider>{children}</NextIntlClientProvider>
           </AccessibilityProvider>

--- a/src/components/layout/appearance-settings.tsx
+++ b/src/components/layout/appearance-settings.tsx
@@ -2,9 +2,8 @@
 
 import { Eye } from 'lucide-react';
 import { useTranslations } from 'next-intl';
-import { useTheme } from 'next-themes';
-
 import { type FontScale, useAccessibility } from '@/components/providers/accessibility-provider';
+import { type Theme, useTheme } from '@/components/providers/theme-provider';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
@@ -21,7 +20,7 @@ const FONT_SCALES: { value: FontScale; px: string }[] = [
 /** Appearance menu: theme + accessibility (text size, motion, contrast). */
 export function AppearanceSettings() {
   const t = useTranslations('settings');
-  const { theme = 'system', setTheme } = useTheme();
+  const { theme, setTheme } = useTheme();
   const { fontScale, setFontScale, reduceMotion, setReduceMotion, highContrast, setHighContrast } = useAccessibility();
 
   return (
@@ -31,7 +30,7 @@ export function AppearanceSettings() {
         <ToggleGroup
           type="single"
           value={theme}
-          onValueChange={(v) => v && setTheme(v)}
+          onValueChange={(v) => v && setTheme(v as Theme)}
           variant="outline"
           size="sm"
           className="w-full"

--- a/src/components/location/location-picker.tsx
+++ b/src/components/location/location-picker.tsx
@@ -77,7 +77,7 @@ export function LocationPicker() {
                   key={place.id}
                   value={place.id}
                   onSelect={() => {
-                    setLocation(makeLocation(place.lat, place.lng, place.name));
+                    setLocation(makeLocation(place.lat, place.lng, place.name, locale));
                     setOpen(false);
                     setQuery('');
                   }}

--- a/src/components/providers/app-state.tsx
+++ b/src/components/providers/app-state.tsx
@@ -6,6 +6,7 @@ import { createContext, useContext, useEffect, useRef, useState, type ReactNode 
 
 import { type CalendarMode, monthAnchor } from '@/lib/calendar';
 import { browserGeolocate } from '@/lib/geo/browser-location';
+import { reverseGeocode } from '@/lib/geo/geocoding';
 import { ipGeolocate } from '@/lib/geo/ip-location';
 import { type AppLocation, DEFAULT_LOCATION, isDefaultLocation, isIsraelTimezone, makeLocation } from '@/lib/location';
 import { DEFAULT_HAVDALAH_OPINION, type HavdalahOpinion, isHavdalahOpinion } from '@/lib/zmanim';
@@ -78,7 +79,7 @@ export function AppStateProvider({
   // The fallback shown until auto-detection resolves (or if it fails) — Jerusalem,
   // with its name in the active language.
   const [location, setLocationState] = useState<AppLocation>(
-    initialLocation ?? { ...DEFAULT_LOCATION, label: tLocation('defaultCity') },
+    initialLocation ?? { ...DEFAULT_LOCATION, label: tLocation('defaultCity'), labelLocale: locale },
   );
 
   // True once the location is explicitly chosen (URL deep link, saved pref, or a
@@ -155,6 +156,31 @@ export function AppStateProvider({
 
     return () => controller.abort();
   }, [urlProvided]);
+
+  // Re-resolve the location label when the UI language changes: a saved label
+  // keeps the locale it was resolved in (e.g. "Петах-Тиква" after switching to
+  // English), and older saves carry no labelLocale at all — both re-resolve
+  // here. Deep-link labels are respected verbatim for the session, and the
+  // default's label is already translated at init.
+  useEffect(() => {
+    if (urlProvided) return;
+    const loc = location;
+    if (isDefaultLocation(loc) || loc.labelLocale === locale) return;
+    const controller = new AbortController();
+    reverseGeocode(loc.lat, loc.lng, controller.signal, locale)
+      .then((name) => {
+        if (!name) return;
+        // Patch only if the location hasn't changed meanwhile, and without
+        // locking — renaming isn't a location choice.
+        setLocationState((prev) =>
+          prev.lat === loc.lat && prev.lng === loc.lng ? { ...prev, label: name, labelLocale: locale } : prev,
+        );
+      })
+      .catch(() => {
+        // Best-effort: keep the stale label; the next mount retries.
+      });
+    return () => controller.abort();
+  }, [location, locale, urlProvided]);
 
   // Persist preferences whenever they change.
   useEffect(() => {

--- a/src/components/providers/theme-provider.tsx
+++ b/src/components/providers/theme-provider.tsx
@@ -1,8 +1,102 @@
 'use client';
 
-import { ThemeProvider as NextThemesProvider } from 'next-themes';
-import type { ComponentProps } from 'react';
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
 
-export function ThemeProvider({ children, ...props }: ComponentProps<typeof NextThemesProvider>) {
-  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+/**
+ * Minimal light/dark/system theme provider (replaces next-themes).
+ *
+ * next-themes renders its pre-paint init as a React <script> element; this
+ * app's [locale] layout remounts on every language switch, and React warns
+ * about (and never executes) client-rendered script tags. Here the pre-paint
+ * script lives in the layout inside a parser-executed innerHTML block (see
+ * `themeInitScript`), and the provider itself only manages state + classes.
+ *
+ * Storage key and html classes ('light'/'dark' + color-scheme) are kept
+ * next-themes-compatible so existing saved preferences survive.
+ */
+
+export type Theme = 'light' | 'dark' | 'system';
+
+const STORAGE_KEY = 'theme';
+
+/** Pre-paint theme application — inline this in the document via innerHTML. */
+export const themeInitScript = `(function(){try{var t=localStorage.getItem('${STORAGE_KEY}');var d=t==='dark'||(t!=='light'&&matchMedia('(prefers-color-scheme: dark)').matches);var e=document.documentElement;e.classList.add(d?'dark':'light');e.style.colorScheme=d?'dark':'light';}catch(e){}})();`;
+
+interface ThemeContextValue {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+function readStoredTheme(): Theme {
+  if (typeof window === 'undefined') return 'system';
+  try {
+    const t = window.localStorage.getItem(STORAGE_KEY);
+    return t === 'light' || t === 'dark' || t === 'system' ? t : 'system';
+  } catch {
+    return 'system';
+  }
+}
+
+/** Swap the html classes without a transition flash on themed properties. */
+function applyTheme(theme: Theme) {
+  const dark = theme === 'dark' || (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+  const css = document.createElement('style');
+  css.appendChild(
+    document.createTextNode('*,*::before,*::after{transition:none!important;animation:none!important}'),
+  );
+  document.head.appendChild(css);
+
+  const el = document.documentElement;
+  el.classList.toggle('dark', dark);
+  el.classList.toggle('light', !dark);
+  el.style.colorScheme = dark ? 'dark' : 'light';
+
+  window.getComputedStyle(document.body); // flush before re-enabling transitions
+  setTimeout(() => document.head.removeChild(css), 1);
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>(readStoredTheme);
+
+  const setTheme = (t: Theme) => {
+    setThemeState(t);
+    try {
+      window.localStorage.setItem(STORAGE_KEY, t);
+    } catch {
+      // Ignore storage errors (private mode, quota, etc.).
+    }
+  };
+
+  // Apply on mount (idempotent after the pre-paint script) and on change;
+  // while in system mode, follow the OS setting live.
+  useEffect(() => {
+    applyTheme(theme);
+    if (theme !== 'system') return;
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const onChange = () => applyTheme('system');
+    mq.addEventListener('change', onChange);
+    return () => mq.removeEventListener('change', onChange);
+  }, [theme]);
+
+  // Follow theme changes made in another tab.
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEY) setThemeState(readStoredTheme());
+    };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, []);
+
+  // The React Compiler memoizes this provider value automatically.
+  const value: ThemeContextValue = { theme, setTheme };
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error('useTheme must be used within ThemeProvider');
+  return ctx;
 }

--- a/src/components/providers/theme-provider.tsx
+++ b/src/components/providers/theme-provider.tsx
@@ -2,6 +2,8 @@
 
 import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
 
+import { THEME_STORAGE_KEY as STORAGE_KEY } from '@/lib/theme';
+
 /**
  * Minimal light/dark/system theme provider (replaces next-themes).
  *
@@ -9,18 +11,12 @@ import { createContext, useContext, useEffect, useState, type ReactNode } from '
  * app's [locale] layout remounts on every language switch, and React warns
  * about (and never executes) client-rendered script tags. Here the pre-paint
  * script lives in the layout inside a parser-executed innerHTML block (see
- * `themeInitScript`), and the provider itself only manages state + classes.
- *
- * Storage key and html classes ('light'/'dark' + color-scheme) are kept
- * next-themes-compatible so existing saved preferences survive.
+ * `themeInitScript` in src/lib/theme.ts — a server-safe module, since strings
+ * exported from a 'use client' module reach Server Components as client-
+ * reference stubs), and the provider itself only manages state + classes.
  */
 
 export type Theme = 'light' | 'dark' | 'system';
-
-const STORAGE_KEY = 'theme';
-
-/** Pre-paint theme application — inline this in the document via innerHTML. */
-export const themeInitScript = `(function(){try{var t=localStorage.getItem('${STORAGE_KEY}');var d=t==='dark'||(t!=='light'&&matchMedia('(prefers-color-scheme: dark)').matches);var e=document.documentElement;e.classList.add(d?'dark':'light');e.style.colorScheme=d?'dark':'light';}catch(e){}})();`;
 
 interface ThemeContextValue {
   theme: Theme;

--- a/src/hooks/use-geolocation.ts
+++ b/src/hooks/use-geolocation.ts
@@ -35,13 +35,17 @@ export function useGeolocation(onDone?: () => void): UseGeolocation {
       async (pos) => {
         const { latitude, longitude } = pos.coords;
         let label = t('myLocation');
+        let labelLocale: string | undefined = locale; // the fallback label is localized too
         try {
           const name = await reverseGeocode(latitude, longitude, undefined, locale);
           if (name) label = name;
+          else labelLocale = undefined;
         } catch {
-          // Reverse geocoding is best-effort; keep the fallback label.
+          // Reverse geocoding is best-effort; keep the localized fallback but
+          // leave labelLocale unset so a real city name can be resolved later.
+          labelLocale = undefined;
         }
-        setLocation(makeLocation(latitude, longitude, label));
+        setLocation(makeLocation(latitude, longitude, label, labelLocale));
         setLocating(false);
         onDone?.();
       },

--- a/src/lib/geo/browser-location.ts
+++ b/src/lib/geo/browser-location.ts
@@ -18,13 +18,18 @@ export function browserGeolocate(fallbackLabel = 'My location', locale = 'en'): 
       async (pos) => {
         const { latitude, longitude } = pos.coords;
         let label = fallbackLabel;
+        let labelLocale: string | undefined;
         try {
           const name = await reverseGeocode(latitude, longitude, undefined, locale);
-          if (name) label = name;
+          if (name) {
+            label = name;
+            labelLocale = locale;
+          }
         } catch {
           // Reverse geocoding is best-effort; keep the fallback label.
+          // labelLocale stays unset so the label can be re-resolved later.
         }
-        resolve(makeLocation(latitude, longitude, label));
+        resolve(makeLocation(latitude, longitude, label, labelLocale));
       },
       () => resolve(null),
       { enableHighAccuracy: false, timeout: 10000, maximumAge: 5 * 60 * 1000 },

--- a/src/lib/geo/ip-location.ts
+++ b/src/lib/geo/ip-location.ts
@@ -34,13 +34,18 @@ export async function ipGeolocate(signal?: AbortSignal, locale = 'en', fallbackL
     if (typeof latitude !== 'number' || typeof longitude !== 'number') return null;
 
     let label = city?.trim() || fallbackLabel;
+    let labelLocale: string | undefined;
     try {
       const localized = await reverseGeocode(latitude, longitude, signal, locale);
-      if (localized) label = localized;
+      if (localized) {
+        label = localized;
+        labelLocale = locale;
+      }
     } catch {
       // Reverse geocoding is best-effort; keep the IP service's city name.
+      // labelLocale stays unset so the label can be re-resolved later.
     }
-    return makeLocation(latitude, longitude, label);
+    return makeLocation(latitude, longitude, label, labelLocale);
   } catch {
     // Network error, abort, bad JSON — all non-fatal; caller keeps the default.
     return null;

--- a/src/lib/location.ts
+++ b/src/lib/location.ts
@@ -5,6 +5,13 @@ export interface AppLocation {
   lng: number;
   timeZoneId: string;
   label: string;
+  /**
+   * The UI locale the label was resolved in. When it doesn't match the active
+   * locale the label is re-resolved (see the app-state relabel effect), so a
+   * persisted "Петах-Тиква" doesn't survive a switch to English. Absent when
+   * the label's language is unknown (deep-link labels, older saved prefs).
+   */
+  labelLocale?: string;
   /** Whether to use the Israel luach (1-day Yom Tov, Israel parsha schedule). */
   inIsrael: boolean;
 }
@@ -14,10 +21,14 @@ export function isIsraelTimezone(timeZoneId: string): boolean {
   return timeZoneId === 'Asia/Jerusalem';
 }
 
-/** Build a location, resolving its IANA timezone locally from the coordinates. */
-export function makeLocation(lat: number, lng: number, label: string): AppLocation {
+/**
+ * Build a location, resolving its IANA timezone locally from the coordinates.
+ * Pass `labelLocale` when the label is known to be in a specific UI language;
+ * omit it for language-neutral or unknown labels.
+ */
+export function makeLocation(lat: number, lng: number, label: string, labelLocale?: string): AppLocation {
   const timeZoneId = tzFromLatLng(lat, lng);
-  return { lat, lng, timeZoneId, label, inIsrael: isIsraelTimezone(timeZoneId) };
+  return { lat, lng, timeZoneId, label, labelLocale, inIsrael: isIsraelTimezone(timeZoneId) };
 }
 
 export const DEFAULT_LOCATION: AppLocation = {

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,14 @@
+/**
+ * Server-safe theme constants. Kept out of the client-marked theme provider:
+ * a Server Component (the locale layout) interpolates `themeInitScript` into
+ * the document, and values imported across the 'use client' boundary arrive
+ * as client-reference stubs, not strings.
+ *
+ * Storage key and html classes ('light'/'dark' + color-scheme) are
+ * next-themes-compatible so previously saved preferences survive.
+ */
+
+export const THEME_STORAGE_KEY = 'theme';
+
+/** Pre-paint theme application — inline this in the document via innerHTML. */
+export const themeInitScript = `(function(){try{var t=localStorage.getItem('${THEME_STORAGE_KEY}');var d=t==='dark'||(t!=='light'&&matchMedia('(prefers-color-scheme: dark)').matches);var e=document.documentElement;e.classList.add(d?'dark':'light');e.style.colorScheme=d?'dark':'light';}catch(e){}})();`;


### PR DESCRIPTION
## Summary

Two locale-switch bugs:

**Stale location label** — the label was reverse-geocoded once in whatever language was active and then persisted, so after switching languages it kept showing e.g. "Петах-Тиква" in the English UI. Every locale-specific label (IP detect, GPS, city search) now carries a `labelLocale` marker, and the app re-reverse-geocodes the coordinates when the active locale differs. Older saved locations without the marker heal the same way; deep-link `?label=` values are respected verbatim for the session; the default city keeps being translated at init.

**Console error on every language switch** — switching locale remounts the `[locale]` layout, and React warns about (and never executes) `<script>` elements rendered on the client. Two offenders:
- the a11y pre-paint script in the layout — now emitted through a parser-executed innerHTML block: it still runs before first paint on a cold load, while client re-renders merely set innerHTML, which is inert per spec;
- the script next-themes injects, which can't be suppressed from outside — replaced next-themes with a ~100-line in-house provider (light/dark/system, live OS tracking, cross-tab sync, no-transition swaps) using the same pre-paint technique. Storage key and html classes are kept compatible, so saved theme preferences carry over; one dependency dropped. Lockfile regenerated on Linux (docker) per the deployment docs — WASM optional deps verified intact.

## Testing

- `lint`, `typecheck`, `test` (86 passing)
- Verified in the running app: ru → en switch relabels Петах-Тиква → Petaẖ Tiqva (and back), zero dev-overlay issues and console errors after the switch, dark theme + font-scale prefs applied pre-paint on cold load and preserved across the switch, theme toggle (light/dark/system) works and persists