### PR TITLE
fix(ui): keep the header inside the viewport when the location name is long

### DIFF
--- a/src/components/layout/site-header.tsx
+++ b/src/components/layout/site-header.tsx
@@ -11,11 +11,11 @@ export function SiteHeader({ right }: { right?: ReactNode }) {
   return (
     <header className="bg-card/80 supports-[backdrop-filter]:bg-card/60 sticky top-0 z-30 shrink-0 border-b backdrop-blur">
       <div className="mx-auto flex h-14 w-full max-w-[2200px] items-center justify-between gap-2 px-4">
-        <Link href="/" className="flex items-center gap-2">
+        <Link href="/" className="flex shrink-0 items-center gap-2">
           <Sunrise className="text-primary size-6" />
           <span className="text-lg font-semibold tracking-tight">{t('brand')}</span>
         </Link>
-        {right && <div className="flex items-center gap-2">{right}</div>}
+        {right && <div className="flex min-w-0 items-center gap-2">{right}</div>}
       </div>
     </header>
   );

--- a/src/components/location/location-picker.tsx
+++ b/src/components/location/location-picker.tsx
@@ -46,7 +46,9 @@ export function LocationPicker() {
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button variant="outline" size="sm" className="max-w-[12rem] gap-1.5">
+        {/* `shrink min-w-0` overrides the button base's shrink-0 so a long city
+            name ellipsizes instead of overflowing the header on narrow screens. */}
+        <Button variant="outline" size="sm" className="min-w-0 shrink max-w-[12rem] gap-1.5">
           <MapPin className="size-4 shrink-0" />
           <span className="truncate">{location.label}</span>
         </Button>

--- a/src/lib/releases.ts
+++ b/src/lib/releases.ts
@@ -18,6 +18,15 @@ export interface Release {
 
 export const RELEASES: readonly Release[] = [
   {
+    version: '1.2',
+    date: '2026-07-05',
+    notes: {
+      en: ['Mobile: long location names no longer overflow the header — they are trimmed with an ellipsis.'],
+      he: ['נייד: שמות מיקום ארוכים כבר לא גולשים מהכותרת — הם מקוצרים עם שלוש נקודות.'],
+      ru: ['Мобильная версия: длинные названия городов больше не растягивают шапку — они обрезаются многоточием.'],
+    },
+  },
+  {
     version: '1.1',
     date: '2026-07-03',
     notes: {


### PR DESCRIPTION
## Problem

On mobile, a long location name (e.g. "Сьюдад-Мадеро") made the header wider than the screen: the settings buttons were pushed past the edge and the whole page scrolled horizontally.

## Cause

The shared `Button` base class sets `shrink-0`, so the location trigger never shrank below its content (up to its `max-w-[12rem]` cap). Brand + location + four icon buttons simply don't fit at ~390px, and no flex item was allowed to give way.

## Fix

- `location-picker.tsx`: the trigger gets `min-w-0 shrink` to override the base `shrink-0`, so the existing `truncate` span ellipsizes the label as space runs out. The 12rem cap still applies on wide screens.
- `site-header.tsx`: the brand link is pinned with `shrink-0` and the right-side group gets `min-w-0`, so the squeeze always lands on the truncating label.

## Verification

Checked in Chrome with device emulation against the dev server: at 390px ("Сьюдад-Мадеро") and at 320px with a 38-character name, `document.documentElement.scrollWidth` equals the viewport width and all header buttons stay visible — at 320px the label collapses to just the pin icon. Desktop is unchanged. Lint, typecheck, and all 116 tests pass.

Bumps the app version to 1.2 with release notes in en/he/ru.

https://claude.ai/code/session_01M3de3eEcUyg8t9LmnybbxF