### PR TITLE
fix(ui): clearer header menu icons, order and tooltips

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -56,10 +56,10 @@ export function App({ initialLocation }: { initialLocation?: AppLocation }) {
             right={
               <>
                 <LocationPicker />
-                <LanguageSwitcher />
-                <CalendarSettings />
                 <ToolsMenu />
+                <LanguageSwitcher />
                 <AppearanceSettings />
+                <CalendarSettings />
               </>
             }
           />

--- a/src/components/layout/appearance-settings.tsx
+++ b/src/components/layout/appearance-settings.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Eye } from 'lucide-react';
+import { Palette } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { type FontScale, useAccessibility } from '@/components/providers/accessibility-provider';
 import { type Theme, useTheme } from '@/components/providers/theme-provider';
@@ -24,7 +24,7 @@ export function AppearanceSettings() {
   const { fontScale, setFontScale, reduceMotion, setReduceMotion, highContrast, setHighContrast } = useAccessibility();
 
   return (
-    <SettingsDialogShell icon={Eye} label={t('appearanceOpen')} title={t('appearanceTitle')}>
+    <SettingsDialogShell icon={Palette} label={t('appearanceOpen')} title={t('appearanceTitle')}>
       <div className="space-y-2">
         <p className="text-sm font-medium">{t('theme')}</p>
         <ToggleGroup

--- a/src/components/layout/calendar-settings.tsx
+++ b/src/components/layout/calendar-settings.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { CalendarCog } from 'lucide-react';
+import { Settings } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 
 import { CANDLE_OFFSET_MAX, CANDLE_OFFSET_MIN, useAppState } from '@/components/providers/app-state';
@@ -93,7 +93,7 @@ export function CalendarSettings() {
   const hidden = new Set(hiddenZmanim);
 
   return (
-    <SettingsDialogShell icon={CalendarCog} label={t('calendarOpen')} title={t('calendarTitle')}>
+    <SettingsDialogShell icon={Settings} label={t('calendarOpen')} title={t('calendarTitle')}>
       <div className="space-y-2">
         <label htmlFor="candle-offset" className="text-sm font-medium">
           {t('candleOffset')}

--- a/src/components/layout/language-switcher.tsx
+++ b/src/components/layout/language-switcher.tsx
@@ -10,6 +10,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { usePathname, useRouter } from '@/i18n/navigation';
 import { routing, type Locale } from '@/i18n/routing';
 
@@ -25,11 +26,18 @@ export function LanguageSwitcher() {
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="icon" aria-label={t('label')}>
-          <Languages className="size-4" />
-        </Button>
-      </DropdownMenuTrigger>
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" size="icon" aria-label={t('label')}>
+                <Languages className="size-4" />
+              </Button>
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent>{t('label')}</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
       <DropdownMenuContent align="end">
         {routing.locales.map((loc) => (
           <DropdownMenuItem key={loc} onClick={() => switchTo(loc)} className={loc === locale ? 'font-semibold' : undefined}>

--- a/src/components/layout/settings-shell.tsx
+++ b/src/components/layout/settings-shell.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 
 /**
  * Shared icon-button-plus-dialog shell for the header's settings menus
@@ -24,11 +25,18 @@ export function SettingsDialogShell({
 }) {
   return (
     <Dialog>
-      <DialogTrigger asChild>
-        <Button variant="outline" size="icon" aria-label={label}>
-          <Icon className="size-4" />
-        </Button>
-      </DialogTrigger>
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DialogTrigger asChild>
+              <Button variant="outline" size="icon" aria-label={label}>
+                <Icon className="size-4" />
+              </Button>
+            </DialogTrigger>
+          </TooltipTrigger>
+          <TooltipContent>{label}</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
       <DialogContent className="sm:max-w-sm">
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>

--- a/src/components/layout/tools-menu.tsx
+++ b/src/components/layout/tools-menu.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Wrench } from 'lucide-react';
+import { LayoutGrid } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 
 import { SettingsDialogShell } from './settings-shell';
@@ -10,7 +10,7 @@ export function ToolsMenu() {
   const t = useTranslations('settings');
 
   return (
-    <SettingsDialogShell icon={Wrench} label={t('toolsOpen')} title={t('toolsTitle')}>
+    <SettingsDialogShell icon={LayoutGrid} label={t('toolsOpen')} title={t('toolsTitle')}>
       <p className="text-muted-foreground text-sm">{t('toolsComingSoon')}</p>
     </SettingsDialogShell>
   );

--- a/src/lib/releases.ts
+++ b/src/lib/releases.ts
@@ -18,6 +18,19 @@ export interface Release {
 
 export const RELEASES: readonly Release[] = [
   {
+    version: '1.3',
+    date: '2026-07-05',
+    notes: {
+      en: [
+        'Clearer header icons: a gear for settings, a palette for appearance and a grid for tools, with tooltips on hover.',
+      ],
+      he: ['סמלים ברורים יותר בכותרת: גלגל שיניים להגדרות, פלטת צבעים למראה ורשת לכלים, עם תיאור בריחוף.'],
+      ru: [
+        'Более понятные значки в шапке: шестерёнка для настроек, палитра для оформления и сетка для инструментов, с подсказками при наведении.',
+      ],
+    },
+  },
+  {
     version: '1.2',
     date: '2026-07-05',
     notes: {


### PR DESCRIPTION
## What

Makes the header's menu buttons self-explanatory:

- **Icons** — calendar/zmanim settings now uses the universal gear (`Settings`, was the hard-to-read `CalendarCog`); appearance uses `Palette` (was `Eye`, which read as show/hide); tools uses `LayoutGrid` (was `Wrench`, which read as settings). Language keeps `Languages`.
- **Order** — now Location · Tools · Language · Appearance · Settings, so the preference cluster sits together at the outer edge with the gear in the corner where users expect settings. Mirrors automatically in RTL.
- **Tooltips** — all four icon buttons show their localized label on hover (shadcn `Tooltip`), reusing the existing `aria-label` translation keys. Touch behavior is unchanged — tapping opens the menu directly.

## Release notes

Bumped to v1.3 with the en/he/ru entry.

## Checks

Lint, typecheck and all 116 unit tests pass; verified in the browser that the dialogs and the language dropdown still open through the new tooltip-wrapped triggers.