### PR TITLE
feat: everyday zmanim defaults, fast-day tzeit opinions, Shabbat-shift notes

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -148,7 +148,10 @@
     "specialShabbat": "Shabbat {name}",
     "molad": "Molad: {weekday}, {time} and {chalakim} chalakim",
     "parasha": "Parashat {name}",
-    "detailsAria": "{label} — details"
+    "detailsAria": "{label} — details",
+    "zmanimSettingsHint": "More zmanim and opinions can be shown via the calendar settings.",
+    "observedPostponed": "Observed later this year because of Shabbat.",
+    "observedAdvanced": "Observed earlier this year because of Shabbat."
   },
   "learning": {
     "title": "Daily learning",

--- a/messages/he.json
+++ b/messages/he.json
@@ -148,7 +148,10 @@
     "specialShabbat": "שבת {name}",
     "molad": "המולד: {weekday}, {time} ו־{chalakim} חלקים",
     "parasha": "פרשת {name}",
-    "detailsAria": "{label} — פרטים"
+    "detailsAria": "{label} — פרטים",
+    "zmanimSettingsHint": "אפשר להציג זמנים ושיטות נוספים בהגדרות לוח השנה.",
+    "observedPostponed": "נדחה השנה בשל שבת.",
+    "observedAdvanced": "הוקדם השנה בשל שבת."
   },
   "learning": {
     "title": "לימוד יומי",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -148,7 +148,10 @@
     "specialShabbat": "Шаббат {name}",
     "molad": "Молад: {weekday}, {time} и {chalakim} халаким",
     "parasha": "Недельная глава: {name}",
-    "detailsAria": "{label} — подробнее"
+    "detailsAria": "{label} — подробнее",
+    "zmanimSettingsHint": "Больше зманим и мнений можно включить в настройках календаря.",
+    "observedPostponed": "В этом году отмечается позже обычного из-за шаббата.",
+    "observedAdvanced": "В этом году отмечается раньше обычного из-за шаббата."
   },
   "learning": {
     "title": "Ежедневное изучение",

--- a/src/components/calendar/calendar-grid.tsx
+++ b/src/components/calendar/calendar-grid.tsx
@@ -183,17 +183,21 @@ export function CalendarGrid() {
       candleLightingOffset,
     });
     const byKey = Object.fromEntries(zmanim.map((z) => [z.key, z.time]));
+    // A cell only has room for one fast-end time — keep the earliest opinion
+    // (Geonim 5.95°); the day panel shows all three.
     const events = getDayEvents(
       cell.date,
       {
         candleLighting: byKey.candleLighting,
         alos: byKey.alosHashachar,
         sunset: byKey.sunset,
+        tzaisGeonim: byKey.tzaisGeonim,
         tzais: byKey.tzais,
+        tzais42: byKey.tzais42,
         havdalah: havdalahTime(havdalahOpinion, byKey),
       },
       location.inIsrael,
-    );
+    ).filter((e) => e.type !== 'fastEnd' || e.zmanKey === 'tzaisGeonim');
 
     return { cell, info, chips, events };
   });

--- a/src/components/layout/language-switcher.tsx
+++ b/src/components/layout/language-switcher.tsx
@@ -21,7 +21,12 @@ export function LanguageSwitcher() {
   const pathname = usePathname();
 
   const switchTo = (next: Locale) => {
-    if (next !== locale) router.replace(pathname, { locale: next });
+    if (next === locale) return;
+    // Keep the query string: it carries the calendar state (?m/?d/?v), so
+    // dropping it snapped the app back to today. Read it from the location —
+    // app-state maintains it via history.replaceState, which the Next router
+    // (and therefore useSearchParams) does not observe.
+    router.replace(`${pathname}${window.location.search}`, { locale: next });
   };
 
   return (

--- a/src/components/layout/settings-shell.tsx
+++ b/src/components/layout/settings-shell.tsx
@@ -45,7 +45,13 @@ export function SettingsDialogShell({
           <TooltipContent>{label}</TooltipContent>
         </Tooltip>
       </TooltipProvider>
-      <DialogContent className={cn('flex max-h-[85dvh] flex-col', wide ? 'sm:max-w-lg' : 'sm:max-w-sm')}>
+      <DialogContent
+        className={cn('flex max-h-[85dvh] flex-col', wide ? 'sm:max-w-lg' : 'sm:max-w-sm')}
+        // Radix focuses the first focusable element on open; when that's a text
+        // input, mobile browsers pop the keyboard over the menu. Keep focus on
+        // the dialog itself — the focus trap still lets keyboard users Tab in.
+        onOpenAutoFocus={(event) => event.preventDefault()}
+      >
         <DialogHeader className="shrink-0">
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>

--- a/src/components/layout/settings-shell.tsx
+++ b/src/components/layout/settings-shell.tsx
@@ -48,9 +48,14 @@ export function SettingsDialogShell({
       <DialogContent
         className={cn('flex max-h-[85dvh] flex-col', wide ? 'sm:max-w-lg' : 'sm:max-w-sm')}
         // Radix focuses the first focusable element on open; when that's a text
-        // input, mobile browsers pop the keyboard over the menu. Keep focus on
-        // the dialog itself — the focus trap still lets keyboard users Tab in.
-        onOpenAutoFocus={(event) => event.preventDefault()}
+        // input, mobile browsers pop the keyboard over the menu. Focus the
+        // dialog container instead (Radix gives it tabIndex=-1): focus still
+        // moves into the modal for keyboard/screen-reader users, but nothing
+        // editable is focused so the keyboard stays closed.
+        onOpenAutoFocus={(event) => {
+          event.preventDefault();
+          (event.currentTarget as HTMLElement | null)?.focus();
+        }}
       >
         <DialogHeader className="shrink-0">
           <DialogTitle>{title}</DialogTitle>

--- a/src/components/providers/app-state.tsx
+++ b/src/components/providers/app-state.tsx
@@ -11,7 +11,13 @@ import { ipGeolocate } from '@/lib/geo/ip-location';
 import { normalizeIsraelAreaTimezone } from '@/lib/geo/timezone';
 import { sanitizeHiddenLearning } from '@/lib/learning';
 import { type AppLocation, DEFAULT_LOCATION, isDefaultLocation, isIsraelTimezone, makeLocation } from '@/lib/location';
-import { DEFAULT_HAVDALAH_OPINION, type HavdalahOpinion, isHavdalahOpinion, sanitizeHiddenZmanim } from '@/lib/zmanim';
+import {
+  DEFAULT_HAVDALAH_OPINION,
+  DEFAULT_HIDDEN_ZMANIM,
+  type HavdalahOpinion,
+  isHavdalahOpinion,
+  sanitizeHiddenZmanim,
+} from '@/lib/zmanim';
 
 export { DEFAULT_LOCATION, makeLocation };
 export type { AppLocation };
@@ -59,6 +65,14 @@ interface PersistedPrefs {
   havdalahOpinion?: HavdalahOpinion;
   /** Hidden (not visible) keys, so zmanim added later default to shown. */
   hiddenZmanim?: string[];
+  /**
+   * True once the user has touched zmanim visibility. Only then does the
+   * persisted hide list override DEFAULT_HIDDEN_ZMANIM — it distinguishes an
+   * explicit "show all" (empty list, customized) from a never-opened picker
+   * (empty-or-default list, not customized), which should track the app
+   * default across releases.
+   */
+  zmanimCustomized?: boolean;
   /** Hidden learning cycles — same hide-list convention as hiddenZmanim. */
   hiddenLearning?: string[];
 }
@@ -119,13 +133,19 @@ export function AppStateProvider({
   };
   const [candleLightingOffset, setCandleLightingOffset] = useState(DEFAULT_CANDLE_OFFSET);
   const [havdalahOpinion, setHavdalahOpinion] = useState<HavdalahOpinion>(DEFAULT_HAVDALAH_OPINION);
-  const [hiddenZmanim, setHiddenZmanim] = useState<string[]>([]);
-  const setZmanVisible = (key: string, visible: boolean) =>
+  const [hiddenZmanim, setHiddenZmanim] = useState<string[]>([...DEFAULT_HIDDEN_ZMANIM]);
+  const [zmanimCustomized, setZmanimCustomized] = useState(false);
+  const setZmanVisible = (key: string, visible: boolean) => {
+    setZmanimCustomized(true);
     setHiddenZmanim((prev) => {
       if (visible) return prev.includes(key) ? prev.filter((k) => k !== key) : prev;
       return prev.includes(key) ? prev : [...prev, key];
     });
-  const showAllZmanim = () => setHiddenZmanim([]);
+  };
+  const showAllZmanim = () => {
+    setZmanimCustomized(true);
+    setHiddenZmanim([]);
+  };
   const [hiddenLearning, setHiddenLearning] = useState<string[]>([]);
   const setLearningVisible = (key: string, visible: boolean) =>
     setHiddenLearning((prev) => {
@@ -148,8 +168,15 @@ export function AppStateProvider({
     }
     if (isHavdalahOpinion(prefs.havdalahOpinion)) setHavdalahOpinion(prefs.havdalahOpinion);
     // Unknown/stale keys are dropped, so a save from an old version self-heals.
+    // The saved hide list only overrides the default set when it's an explicit
+    // choice (zmanimCustomized). Legacy saves predate the flag: there a
+    // non-empty list was deliberate, while an empty one just mirrored the old
+    // show-everything default — those users move to the current default.
     const savedHidden = sanitizeHiddenZmanim(prefs.hiddenZmanim);
-    if (savedHidden.length > 0) setHiddenZmanim(savedHidden);
+    if (prefs.zmanimCustomized ?? savedHidden.length > 0) {
+      setHiddenZmanim(savedHidden);
+      setZmanimCustomized(true);
+    }
     const savedHiddenLearning = sanitizeHiddenLearning(prefs.hiddenLearning);
     if (savedHiddenLearning.length > 0) setHiddenLearning(savedHiddenLearning);
     // A location from the URL (deep link) takes precedence over the saved one.
@@ -224,12 +251,12 @@ export function AppStateProvider({
     try {
       window.localStorage.setItem(
         STORAGE_KEY,
-        JSON.stringify({ location, candleLightingOffset, havdalahOpinion, hiddenZmanim, hiddenLearning }),
+        JSON.stringify({ location, candleLightingOffset, havdalahOpinion, hiddenZmanim, zmanimCustomized, hiddenLearning }),
       );
     } catch {
       // Ignore storage errors (private mode, quota, etc.).
     }
-  }, [location, candleLightingOffset, havdalahOpinion, hiddenZmanim, hiddenLearning]);
+  }, [location, candleLightingOffset, havdalahOpinion, hiddenZmanim, zmanimCustomized, hiddenLearning]);
 
   // Restore calendar state (mode + selected day + viewed month) from the URL on
   // mount, so a shared link reopens the same view. Read post-mount to stay
@@ -263,7 +290,18 @@ export function AppStateProvider({
 
   // Reflect mode + selected day + viewed month in the URL (without a
   // navigation) for sharing and reloads.
+  const reflectedOnce = useRef(false);
   useEffect(() => {
+    // Skip the mount run: it fires before the URL-restore effect's setStates
+    // have re-rendered, so it would overwrite the very params restore just
+    // read with the initial (today) state. That clobber broke locale
+    // switching — the switch remounts this provider, and the re-read URL had
+    // already been reset to today. Any state change re-runs this with fresh
+    // values; until then the URL already says what the state says.
+    if (!reflectedOnce.current) {
+      reflectedOnce.current = true;
+      return;
+    }
     const p = new URLSearchParams(window.location.search);
     p.set('m', mode);
     const iso = selectedDay.toISODate();

--- a/src/components/zmanim/zmanim-list.test.tsx
+++ b/src/components/zmanim/zmanim-list.test.tsx
@@ -29,6 +29,12 @@ const groups: ZmanGroup[] = [
         rows: [{ key: 'sunrise', shita: '', detail: 'The ideal time to begin the morning Shema.', time: DateTime.fromISO('2024-03-20T05:42:00', { zone: 'Asia/Jerusalem' }) }],
       },
       {
+        base: 'tzais',
+        name: 'Tzeit ha-Kochavim',
+        description: 'Sun 8.5° below the horizon.',
+        rows: [{ key: 'tzais', shita: '3 stars · 8.5°', detail: 'Sun 8.5° below the horizon.', time: DateTime.fromISO('2024-03-20T18:40:00', { zone: 'Asia/Jerusalem' }) }],
+      },
+      {
         base: 'sofZmanShma',
         name: 'Latest Shema',
         description: 'Latest time to recite the morning Shema.',
@@ -62,6 +68,28 @@ describe('ZmanimList', () => {
     expect(screen.getByRole('button', { name: 'Magen Avraham — details' })).toBeInTheDocument();
     expect(screen.queryByText('Latest time to recite the morning Shema.')).not.toBeInTheDocument();
     expect(screen.queryByText('MGA — dawn to nightfall.')).not.toBeInTheDocument();
+  });
+
+  it('renders a single-shita zman inline: shita next to the name, no indented block', () => {
+    render(<ZmanimList groups={groups} />);
+    const shita = screen.getByText('3 stars · 8.5°');
+    // Name, shita and time all share the one <li> — no nested per-opinion
+    // rows like multi-shita zmanim use.
+    const row = shita.closest('li')!;
+    expect(row).toContainElement(screen.getByText('Tzeit ha-Kochavim'));
+    expect(row).toContainElement(screen.getByText(/6:40/));
+    expect(row.querySelectorAll('li')).toHaveLength(0);
+  });
+
+  it('renders the footnote after the groups when provided, omits it otherwise', () => {
+    const { rerender } = render(<ZmanimList groups={groups} footnote="More zmanim in settings." />);
+    expect(screen.getByText('More zmanim in settings.')).toBeInTheDocument();
+    rerender(
+      <NextIntlClientProvider locale="en" messages={messages}>
+        <ZmanimList groups={groups} />
+      </NextIntlClientProvider>,
+    );
+    expect(screen.queryByText('More zmanim in settings.')).not.toBeInTheDocument();
   });
 
   it('formats a time and shows a dash for a null time', () => {

--- a/src/components/zmanim/zmanim-list.tsx
+++ b/src/components/zmanim/zmanim-list.tsx
@@ -26,13 +26,16 @@ function ZmanName({ name, description }: { name: string; description?: string })
 }
 
 function BaseItem({ item, locale }: { item: ZmanBaseGroup; locale: string }) {
-  // Single opinion → flat row.
+  // Single opinion → flat row, with the shita inline next to the name (an
+  // indented one-row block would waste a line). flex-wrap drops the shita
+  // under the name when the row is too narrow to fit everything.
   if (item.rows.length === 1) {
     const row = item.rows[0];
     return (
       <li className="flex items-center justify-between gap-3">
-        <div className="min-w-0">
+        <div className="flex min-w-0 flex-wrap items-center gap-x-1.5">
           <ZmanName name={item.name} description={item.description} />
+          {row.shita && <span className="text-muted-foreground text-xs">{row.shita}</span>}
         </div>
         <Time time={row.time} locale={locale} />
       </li>
@@ -61,19 +64,31 @@ function BaseItem({ item, locale }: { item: ZmanBaseGroup; locale: string }) {
 }
 
 /** Pure, hook-free grouped zmanim list — usable in both server and client components. */
-export function ZmanimList({ groups, locale = 'en' }: { groups: ZmanGroup[]; locale?: string }) {
+export function ZmanimList({
+  groups,
+  locale = 'en',
+  footnote,
+}: {
+  groups: ZmanGroup[];
+  locale?: string;
+  /** Small muted note under the list (e.g. "more zmanim in settings"). */
+  footnote?: string;
+}) {
   return (
-    <div className="space-y-4 2xl:grid 2xl:grid-cols-2 2xl:gap-x-10 2xl:gap-y-4 2xl:space-y-0">
-      {groups.map((group) => (
-        <section key={group.category}>
-          <SectionHeading>{group.label}</SectionHeading>
-          <ul className="space-y-1.5">
-            {group.items.map((item) => (
-              <BaseItem key={item.base} item={item} locale={locale} />
-            ))}
-          </ul>
-        </section>
-      ))}
+    <div>
+      <div className="space-y-4 2xl:grid 2xl:grid-cols-2 2xl:gap-x-10 2xl:gap-y-4 2xl:space-y-0">
+        {groups.map((group) => (
+          <section key={group.category}>
+            <SectionHeading>{group.label}</SectionHeading>
+            <ul className="space-y-1.5">
+              {group.items.map((item) => (
+                <BaseItem key={item.base} item={item} locale={locale} />
+              ))}
+            </ul>
+          </section>
+        ))}
+      </div>
+      {footnote && <p className="text-muted-foreground mt-4 text-xs">{footnote}</p>}
     </div>
   );
 }

--- a/src/components/zmanim/zmanim-panel.tsx
+++ b/src/components/zmanim/zmanim-panel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { JewishCalendar } from 'kosher-zmanim';
-import { BookOpen, Flame, Moon, Sparkles, Utensils, UtensilsCrossed, Wheat } from 'lucide-react';
+import { BookOpen, CalendarClock, Flame, Moon, Sparkles, Utensils, UtensilsCrossed, Wheat } from 'lucide-react';
 import { useLocale, useTranslations } from 'next-intl';
 import { DateTime } from 'luxon';
 import type { LucideIcon } from 'lucide-react';
@@ -66,7 +66,9 @@ function dayEventsFor(
       candleLighting: byKey.candleLighting,
       alos: byKey.alosHashachar,
       sunset: byKey.sunset,
+      tzaisGeonim: byKey.tzaisGeonim,
       tzais: byKey.tzais,
+      tzais42: byKey.tzais42,
       havdalah: havdalahTime(havdalahOpinion, byKey),
     },
     location.inIsrael,
@@ -112,9 +114,30 @@ function buildDayTimes(
   }
 
   // Same-day fast events (minor fasts, Yom Kippur, Tisha B'Av).
-  const fasts = dayEventsFor(selectedDay, location, candleLightingOffset, havdalahOpinion).filter(
+  let fasts = dayEventsFor(selectedDay, location, candleLightingOffset, havdalahOpinion).filter(
     (e) => e.type === 'fastStart' || e.type === 'fastEnd',
   );
+
+  // Tisha B'Av spans two civil days (sunset on the eve → nightfall), so show
+  // BOTH its bookends on both days, mirroring the rest-day bookends above.
+  // Yom Kippur needs nothing here: as a rest day its onset/end already appear
+  // on both days as candle lighting / havdalah. (Minor fasts are dawn→nightfall
+  // within one day.)
+  const isTishaBav = (d: DateTime) => {
+    const jc = new JewishCalendar(d);
+    jc.setInIsrael(inIsrael);
+    return jc.getYomTovIndex() === JewishCalendar.TISHA_BEAV;
+  };
+  if (isTishaBav(selectedDay)) {
+    // The day itself: prepend the onset (yesterday's sunset) from the eve.
+    const eve = dayEventsFor(selectedDay.minus({ days: 1 }), location, candleLightingOffset, havdalahOpinion);
+    const start = eve.find((e) => e.type === 'fastStart');
+    if (start) fasts = [start, ...fasts];
+  } else if (isTishaBav(selectedDay.plus({ days: 1 }))) {
+    // The eve: append tomorrow's fast-end times after tonight's onset.
+    const day = dayEventsFor(selectedDay.plus({ days: 1 }), location, candleLightingOffset, havdalahOpinion);
+    fasts = [...fasts, ...day.filter((e) => e.type === 'fastEnd')];
+  }
 
   return [...bookends, ...fasts];
 }
@@ -196,6 +219,10 @@ export function ZmanimPanel() {
   // Candle lighting + havdalah for the rest period (both bookends on both days),
   // plus any fast times for the selected day.
   const events = buildDayTimes(selectedDay, location, candleLightingOffset, havdalahOpinion);
+  // The fast end arrives once per tzeit opinion — render those as one grouped
+  // block instead of repeating the "Fast ends" row three times.
+  const fastEndEvents = events.filter((e) => e.type === 'fastEnd');
+  const singleEvents = events.filter((e) => e.type !== 'fastEnd');
 
   // Candle lighting now lives in the events strip above, so keep it out of the
   // zmanim list to avoid showing the same time twice. User-hidden zmanim are
@@ -229,6 +256,14 @@ export function ZmanimPanel() {
             ))}
           </div>
         )}
+        {/* An observance kept off its nominal date (fast nidche, the Israeli
+            national days) — say so, so the "wrong"-looking date isn't a puzzle. */}
+        {info.observedShift && (
+          <p className="text-muted-foreground mt-0.5 flex items-center gap-1.5 text-xs">
+            <CalendarClock className="size-3.5 shrink-0 text-amber-600 dark:text-amber-400" />
+            {tPanel(info.observedShift === 'postponed' ? 'observedPostponed' : 'observedAdvanced')}
+          </p>
+        )}
         {info.molad && (
           <p className="text-muted-foreground mt-0.5 flex items-center gap-1.5 text-xs">
             <Moon className="size-3.5 shrink-0 text-blue-500 dark:text-blue-400" />
@@ -237,7 +272,7 @@ export function ZmanimPanel() {
         )}
         {events.length > 0 && (
           <div className="mt-1.5 flex flex-col gap-1.5">
-            {events.map((event, i) => {
+            {singleEvents.map((event, i) => {
               const { Icon, className } = EVENT_META[event.type];
               return (
                 <div key={`${event.type}-${i}`} className="flex items-center justify-between gap-3 text-sm">
@@ -259,13 +294,31 @@ export function ZmanimPanel() {
                 </div>
               );
             })}
+            {/* Fast end comes once per tzeit opinion — one labeled block with a
+                compact row per opinion, like a multi-shita zman in the list. */}
+            {fastEndEvents.length > 0 && (
+              <div>
+                <span className="flex items-center gap-2 text-sm font-medium">
+                  <EVENT_META.fastEnd.Icon className={cn('size-4 shrink-0', EVENT_META.fastEnd.className)} />
+                  {tEvents('fastEnd')}
+                </span>
+                <div className="mt-1 space-y-1 ps-6">
+                  {fastEndEvents.map((event) => (
+                    <div key={event.zmanKey} className="flex items-center justify-between gap-3">
+                      <span className="text-muted-foreground text-xs">{event.zmanKey ? tShita(event.zmanKey) : ''}</span>
+                      <time className="font-mono text-sm tabular-nums">{formatTime(event.time, locale)}</time>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
           </div>
         )}
       </CardHeader>
       <Separator />
       <CardContent className="flex flex-col gap-4 px-5 py-3 lg:min-h-0 lg:flex-1 lg:overflow-y-auto">
         <DailyLearning date={selectedDay} inIsrael={location.inIsrael} locale={locale} />
-        <ZmanimList groups={groups} locale={locale} />
+        <ZmanimList groups={groups} locale={locale} footnote={tPanel('zmanimSettingsHint')} />
       </CardContent>
     </Card>
   );

--- a/src/lib/calendar/day-events.test.ts
+++ b/src/lib/calendar/day-events.test.ts
@@ -8,7 +8,9 @@ const TIMES = {
   candleLighting: DateTime.fromISO('2024-01-01T18:00'),
   alos: DateTime.fromISO('2024-01-01T04:00'),
   sunset: DateTime.fromISO('2024-01-01T18:18'),
+  tzaisGeonim: DateTime.fromISO('2024-01-01T18:45'),
   tzais: DateTime.fromISO('2024-01-01T18:50'),
+  tzais42: DateTime.fromISO('2024-01-01T19:00'),
   // Distinct from tzais, so we can assert havdalah uses the chosen-opinion time.
   havdalah: DateTime.fromISO('2024-01-01T19:05'),
 };
@@ -28,11 +30,13 @@ describe('getDayEvents', () => {
     expect(e[0]).toMatchObject({ type: 'havdalah', time: TIMES.havdalah });
   });
 
-  it('shows fast begin (dawn) and end (nightfall) for a minor fast', () => {
+  it('shows fast begin (dawn) and end at all three tzeit opinions for a minor fast', () => {
     const e = getDayEvents(DateTime.fromISO('2024-07-23'), TIMES); // 17 Tammuz
     expect(e).toEqual([
       { type: 'fastStart', time: TIMES.alos },
-      { type: 'fastEnd', time: TIMES.tzais },
+      { type: 'fastEnd', time: TIMES.tzaisGeonim, zmanKey: 'tzaisGeonim' },
+      { type: 'fastEnd', time: TIMES.tzais, zmanKey: 'tzais' },
+      { type: 'fastEnd', time: TIMES.tzais42, zmanKey: 'tzais42' },
     ]);
   });
 
@@ -45,10 +49,20 @@ describe('getDayEvents', () => {
     expect(events('2024-04-30')).toEqual(['havdalah']);
   });
 
-  it('handles Tisha B’Av: onset on the eve, end on the day', () => {
+  it('handles Tisha B’Av: onset on the eve, end on the day at all three opinions', () => {
     expect(events('2024-08-12')).toEqual(['fastStart']); // erev → sunset onset
     const day = getDayEvents(DateTime.fromISO('2024-08-13'), TIMES);
-    expect(day).toEqual([{ type: 'fastEnd', time: TIMES.tzais }]);
+    expect(day).toEqual([
+      { type: 'fastEnd', time: TIMES.tzaisGeonim, zmanKey: 'tzaisGeonim' },
+      { type: 'fastEnd', time: TIMES.tzais, zmanKey: 'tzais' },
+      { type: 'fastEnd', time: TIMES.tzais42, zmanKey: 'tzais42' },
+    ]);
+  });
+
+  it('keeps Yom Kippur as a single havdalah (no triple fast end)', () => {
+    // 2024-10-12 is Yom Kippur (a Saturday) → ends tonight as havdalah.
+    const e = getDayEvents(DateTime.fromISO('2024-10-12'), TIMES);
+    expect(e).toEqual([{ type: 'havdalah', time: TIMES.havdalah }]);
   });
 
   it('shows nothing on an ordinary weekday', () => {

--- a/src/lib/calendar/day-events.ts
+++ b/src/lib/calendar/day-events.ts
@@ -3,9 +3,18 @@ import type { DateTime } from 'luxon';
 
 export type DayEventType = 'candle' | 'havdalah' | 'fastStart' | 'fastEnd';
 
+/** The tzeit opinions a fast end is shown at, earliest to latest. */
+export const FAST_END_OPINIONS = ['tzaisGeonim', 'tzais', 'tzais42'] as const;
+export type FastEndOpinion = (typeof FAST_END_OPINIONS)[number];
+
 export interface DayEvent {
   type: DayEventType;
   time: DateTime | null;
+  /**
+   * The tzeit opinion this time uses — set on fastEnd events only, which are
+   * emitted once per FAST_END_OPINIONS entry. Translatable via zmanim.shitot.
+   */
+  zmanKey?: FastEndOpinion;
 }
 
 /** The zmanim a day's events can reference. */
@@ -13,8 +22,12 @@ export interface DayEventTimes {
   candleLighting: DateTime | null;
   alos: DateTime | null;
   sunset: DateTime | null;
-  /** Standard nightfall (8.5°) — used for fast ends. */
+  /** Nightfall of the Geonim (5.95°) — the earliest fast-end opinion. */
+  tzaisGeonim: DateTime | null;
+  /** Standard nightfall (8.5°). */
   tzais: DateTime | null;
+  /** Fixed 42 minutes after sunset — the latest fast-end opinion. */
+  tzais42: DateTime | null;
   /** Nightfall for havdalah, per the user's chosen opinion (may differ from `tzais`). */
   havdalah: DateTime | null;
 }
@@ -69,8 +82,12 @@ export function getDayEvents(date: DateTime, times: DayEventTimes, inIsrael = fa
       events.push({ type: 'fastStart', time: times.alos });
     }
     // Yom Kippur's end is already shown as havdalah; avoid a duplicate nightfall.
+    // The end is given at all three tzeit opinions — displays that only have
+    // room for one (the calendar grid) keep the earliest (Geonim 5.95°).
     if (!endsTonight) {
-      events.push({ type: 'fastEnd', time: times.tzais });
+      for (const zmanKey of FAST_END_OPINIONS) {
+        events.push({ type: 'fastEnd', time: times[zmanKey], zmanKey });
+      }
     }
   }
 

--- a/src/lib/calendar/day-info.test.ts
+++ b/src/lib/calendar/day-info.test.ts
@@ -49,6 +49,29 @@ describe('getDayInfo', () => {
     expect(info.yomTovIndex).toBe(31);
   });
 
+  describe('observedShift', () => {
+    it.each([
+      ['2022-07-17', 'postponed'], // 17 Tammuz 5782 fell on Shabbat → fast on Sunday 18 Tammuz
+      ['2022-08-07', 'postponed'], // 9 Av 5782 fell on Shabbat → fast on Sunday 10 Av
+      ['2024-03-21', 'advanced'], // 13 Adar II 5784 fell on Shabbat → Ta'anit Esther on Thursday 11 Adar II
+      ['2024-05-14', 'postponed'], // 5 Iyar 5784 fell on Monday → Yom HaAtzmaut on Tuesday 6 Iyar
+      ['2024-05-13', 'postponed'], // …and Yom HaZikaron moved with it, 4 → 5 Iyar
+    ])('flags %s as %s because of Shabbat', (iso, shift) => {
+      const info = getDayInfo(DateTime.fromISO(iso));
+      expect(info.observedShift).toBe(shift);
+    });
+
+    it('is null when the observance falls on its nominal date', () => {
+      expect(getDayInfo(DateTime.fromISO('2026-07-02')).observedShift).toBeNull(); // 17 Tammuz in place
+      expect(getDayInfo(DateTime.fromISO('2026-07-23')).observedShift).toBeNull(); // 9 Av in place
+      expect(getDayInfo(DateTime.fromISO('2026-04-22')).observedShift).toBeNull(); // Yom HaAtzmaut on 5 Iyar
+    });
+
+    it('is null on the nominal date itself when the observance moved away', () => {
+      expect(getDayInfo(DateTime.fromISO('2022-07-16')).observedShift).toBeNull(); // Shabbat 17 Tammuz — no fast
+    });
+  });
+
   it.each([
     ['2024-04-20', 'Hagadol'], // Shabbat before Pesach
     ['2024-10-05', 'Shuva'], // Shabbat between Rosh Hashana and Yom Kippur

--- a/src/lib/calendar/day-info.ts
+++ b/src/lib/calendar/day-info.ts
@@ -86,6 +86,33 @@ function getWeekParsha(date: DateTime, fmt: HebrewDateFormatter, inIsrael: boole
   return fmt.formatParsha(jc) || null;
 }
 
+/**
+ * Nominal Hebrew day-of-month for observances kosher-zmanim reports on a
+ * shifted date when the nominal one collides with Shabbat: the fasts that are
+ * nidche (postponed past Shabbat) or advanced (Ta'anit Esther), and the
+ * Israeli national days, which move by the Knesset rules. The month needn't be
+ * checked — the yomTovIndex already pins the observance.
+ */
+const NOMINAL_DAY_OF_MONTH: Record<number, number> = {
+  [JewishCalendar.FAST_OF_GEDALYAH]: 3, // Tishrei
+  [JewishCalendar.SEVENTEEN_OF_TAMMUZ]: 17,
+  [JewishCalendar.TISHA_BEAV]: 9,
+  [JewishCalendar.FAST_OF_ESTHER]: 13, // Adar
+  [JewishCalendar.YOM_HASHOAH]: 27, // Nissan
+  [JewishCalendar.YOM_HAZIKARON]: 4, // Iyar
+  [JewishCalendar.YOM_HAATZMAUT]: 5, // Iyar
+};
+
+/** Is this day's observance kept off its nominal date because of Shabbat? */
+function observedShift(jc: JewishCalendar): DayInfo['observedShift'] {
+  const nominal = NOMINAL_DAY_OF_MONTH[jc.getYomTovIndex()];
+  if (nominal === undefined) return null;
+  const day = jc.getJewishDayOfMonth();
+  if (day > nominal) return 'postponed';
+  if (day < nominal) return 'advanced';
+  return null;
+}
+
 /** Is the day Erev Pesach (14 Nissan) — when the chametz deadlines apply? */
 export function isErevPesach(date: DateTime): boolean {
   return new JewishCalendar(date).getYomTovIndex() === JewishCalendar.EREV_PESACH;
@@ -122,6 +149,7 @@ export function getDayInfo(date: DateTime, formatter?: HebrewDateFormatter, loca
     // Chodesh info; on a 30th (first RC day) getMolad already reads the
     // incoming month.
     molad: isRoshChodesh || isShabbosMevorchim ? getMolad(date) : null,
+    observedShift: observedShift(jc),
     hebrewDayOfMonth: jc.getJewishDayOfMonth(),
     hebrewMonth: hebrewMonthLabel(jc, fmt, locale),
   };

--- a/src/lib/calendar/index.ts
+++ b/src/lib/calendar/index.ts
@@ -1,5 +1,5 @@
 export { createHebrewFormatter, getDayInfo, isErevPesach } from './day-info';
-export { type DayEvent, type DayEventType, getDayEvents } from './day-events';
+export { type DayEvent, type DayEventType, FAST_END_OPINIONS, type FastEndOpinion, getDayEvents } from './day-events';
 export { getMolad, type MoladInfo } from './molad';
 export { localizedHolidayLabel, ruHolidayLabel } from './holidays-ru';
 export { RU_MONTHS, RU_MONTHS_GENITIVE } from './months-ru';

--- a/src/lib/calendar/types.ts
+++ b/src/lib/calendar/types.ts
@@ -50,6 +50,12 @@ export interface DayInfo {
   isShabbosMevorchim: boolean;
   /** Molad of the incoming month — set on Rosh Chodesh & Shabbos Mevorchim, else null. */
   molad: MoladInfo | null;
+  /**
+   * Set when the day's observance is kept on a different date than its nominal
+   * one because of Shabbat (e.g. a fast that is nidche, or the Israeli national
+   * days): 'postponed' = kept later, 'advanced' = kept earlier. Null otherwise.
+   */
+  observedShift: 'postponed' | 'advanced' | null;
   /** Hebrew day-of-month number (1-30). */
   hebrewDayOfMonth: number;
   /** Formatted Hebrew month name. */

--- a/src/lib/releases.ts
+++ b/src/lib/releases.ts
@@ -18,6 +18,36 @@ export interface Release {
 
 export const RELEASES: readonly Release[] = [
   {
+    version: '1.6',
+    date: '2026-07-05',
+    notes: {
+      en: [
+        'The day panel now shows only the everyday zmanim by default — more zmanim and opinions can be enabled in the calendar settings.',
+        'A zman with a single opinion now fits on one line.',
+        'Fast ends are shown at three tzeit opinions; Tisha B’Av times appear on both the eve and the fast day.',
+        'Opening a settings menu on mobile no longer pops up the keyboard.',
+        'When a fast or national day is observed off its usual date because of Shabbat, the day panel says so.',
+        'Switching the language keeps the selected day instead of jumping back to today.',
+      ],
+      he: [
+        'פאנל היום מציג כעת כברירת מחדל רק את הזמנים השימושיים — זמנים ושיטות נוספים אפשר להפעיל בהגדרות לוח השנה.',
+        'זמן עם שיטה אחת מוצג כעת בשורה אחת.',
+        'סיום הצום מוצג בשלוש שיטות צאת הכוכבים; זמני תשעה באב מוצגים גם בערב הצום וגם ביום עצמו.',
+        'פתיחת תפריט הגדרות בנייד כבר לא מקפיצה את המקלדת.',
+        'כשצום או יום לאומי נדחה או הוקדם בשל שבת, פאנל היום מציין זאת.',
+        'החלפת שפה שומרת על היום שנבחר במקום לחזור להיום.',
+      ],
+      ru: [
+        'Панель дня теперь по умолчанию показывает только основные зманим — остальные зманим и мнения можно включить в настройках календаря.',
+        'Зман с одним мнением теперь помещается в одну строку.',
+        'Окончание поста показано по трём мнениям о выходе звёзд; времена Девятого ава видны и накануне, и в сам день поста.',
+        'Открытие меню настроек на мобильном больше не вызывает клавиатуру.',
+        'Если пост или национальный день перенесён из-за шаббата, панель дня сообщает об этом.',
+        'Смена языка сохраняет выбранный день, а не возвращает к сегодняшнему.',
+      ],
+    },
+  },
+  {
     version: '1.5',
     date: '2026-07-05',
     notes: {

--- a/src/lib/zmanim/index.ts
+++ b/src/lib/zmanim/index.ts
@@ -10,4 +10,4 @@ export {
   isHavdalahOpinion,
 } from './havdalah';
 export type { ComputedZman, ComputeZmanimInput, ZmanCategory, ZmanDefinition } from './types';
-export { CONFIGURABLE_ZMANIM, sanitizeHiddenZmanim } from './visibility';
+export { CONFIGURABLE_ZMANIM, DEFAULT_HIDDEN_ZMANIM, sanitizeHiddenZmanim } from './visibility';

--- a/src/lib/zmanim/visibility.test.ts
+++ b/src/lib/zmanim/visibility.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { ZMANIM } from './definitions';
-import { CONFIGURABLE_ZMANIM, sanitizeHiddenZmanim } from './visibility';
+import { CONFIGURABLE_ZMANIM, DEFAULT_HIDDEN_ZMANIM, sanitizeHiddenZmanim } from './visibility';
 
 describe('CONFIGURABLE_ZMANIM', () => {
   it('is every zman except candle lighting and the Erev Pesach-only ones', () => {
@@ -9,6 +9,30 @@ describe('CONFIGURABLE_ZMANIM', () => {
     expect(keys).not.toContain('candleLighting');
     expect(keys).not.toContain('sofZmanAchilasChametzGRA');
     expect(keys).toEqual(ZMANIM.filter((z) => z.key !== 'candleLighting' && !z.erevPesachOnly).map((z) => z.key));
+  });
+});
+
+describe('DEFAULT_HIDDEN_ZMANIM', () => {
+  it('leaves exactly the everyday one-shita-per-zman set visible', () => {
+    const hidden = new Set(DEFAULT_HIDDEN_ZMANIM);
+    const visible = CONFIGURABLE_ZMANIM.map((z) => z.key).filter((k) => !hidden.has(k));
+    expect(visible).toEqual([
+      'alosHashachar', // 16.1°
+      'misheyakir102', // 10.2°
+      'sunrise',
+      'sofZmanShmaGRA',
+      'sofZmanTfilaGRA',
+      'chatzos',
+      'minchaGedola',
+      'minchaKetana',
+      'plagHamincha',
+      'sunset',
+      'tzais', // 8.5°
+    ]);
+  });
+
+  it('is a valid persisted hide list (survives sanitize unchanged)', () => {
+    expect(sanitizeHiddenZmanim([...DEFAULT_HIDDEN_ZMANIM])).toEqual([...DEFAULT_HIDDEN_ZMANIM]);
   });
 });
 

--- a/src/lib/zmanim/visibility.ts
+++ b/src/lib/zmanim/visibility.ts
@@ -15,6 +15,34 @@ export const CONFIGURABLE_ZMANIM: readonly ZmanDefinition[] = ZMANIM.filter(
 const CONFIGURABLE_KEYS = new Set(CONFIGURABLE_ZMANIM.map((z) => z.key));
 
 /**
+ * The zmanim shown out of the box — the common everyday set, one shita per
+ * zman: alot 16.1°, misheyakir 10.2°, Shma/Tfila by the Vilna Gaon, tzeit
+ * 8.5°. Everything else starts hidden; a note under the day panel's list
+ * points users to the settings picker to turn more on.
+ */
+const DEFAULT_VISIBLE_KEYS = new Set([
+  'alosHashachar',
+  'misheyakir102',
+  'sunrise',
+  'sofZmanShmaGRA',
+  'sofZmanTfilaGRA',
+  'chatzos',
+  'minchaGedola',
+  'minchaKetana',
+  'plagHamincha',
+  'sunset',
+  'tzais',
+]);
+
+/**
+ * The default hidden set, derived as the complement of DEFAULT_VISIBLE_KEYS so
+ * visibility state keeps its hide-list convention (see sanitizeHiddenZmanim).
+ */
+export const DEFAULT_HIDDEN_ZMANIM: readonly string[] = CONFIGURABLE_ZMANIM.filter(
+  (z) => !DEFAULT_VISIBLE_KEYS.has(z.key),
+).map((z) => z.key);
+
+/**
  * Validate a persisted hidden-zmanim preference. Visibility is stored as the
  * set of HIDDEN keys (not visible ones) so zmanim added in future releases
  * default to shown for existing users. Unknown or malformed entries are


### PR DESCRIPTION
## Summary

- **Default zmanim set**: the day panel now opens with only the everyday zmanim — alot 16.1°, misheyakir 10.2°, hanetz, Shema/Tefila (GRA), chatzot, mincha gedola/ketana, plag, shkia, tzeit 8.5°. Everything else starts hidden; a note under the list points to the calendar settings. The persisted hide list gains a `zmanimCustomized` flag so an explicit "show all" survives reloads, while users who never touched the picker follow the app default across releases (legacy saves with a deliberate hide list keep it).
- **Single-opinion rows inline**: a zman displayed with one shita renders on one line, opinion in small grey type next to the name (wraps when narrow).
- **Fast ends at three tzeit opinions**: Geonim 5.95°, 3 stars 8.5°, fixed 42 min — grouped under a single "Fast ends" row in the panel; the calendar grid keeps only the earliest (5.95°). Yom Kippur is untouched (still a single havdalah).
- **Tisha B'Av on both days**: the panel shows the fast's start and end times on the eve *and* the fast day, mirroring the Shabbat candle/havdalah bookends.
- **Shabbat-shift notes**: when a fast or Israeli national day is observed off its nominal date (nidche fasts, advanced Ta'anit Esther, the Knesset-rule shifts), the panel says "Observed later/earlier this year because of Shabbat."
- **Language switch keeps the selected day**: the switcher now preserves the query string (read from `window.location` — the calendar state is written via `history.replaceState`, which the Next router doesn't observe), and the URL-reflect effect skips its mount run so it can no longer clobber the restored `?d/?v/?m` params on remount.
- **Settings dialogs no longer autofocus** a text field, so the mobile keyboard stays closed until needed.
- Version bumped to 1.6 with release notes in en/he/ru.

## Test plan

- `npm run lint`, `npm run typecheck`, `npm test` — 168 tests pass, including new coverage for the default-visible set, inline single-shita rendering, the list footnote, three-opinion fast ends (17 Tammuz, Tisha B'Av, Yom Kippur negative case), and observed-shift detection (2022 nidche fasts, 2024 advanced Ta'anit Esther, 2024 Yom HaZikaron/HaAtzmaut shifts, null cases).
- Verified in the running app: fresh-profile defaults, show-all/legacy persistence paths, fast-day rendering on 17 Tammuz + both Tisha B'Av days, the Shabbat-shift note on 2022-07-17, and EN→RU switching keeping the selected day.