### PR TITLE
fix(calendar): scale cell content with a transform, not zoom

### DIFF
--- a/src/components/calendar/calendar-day.tsx
+++ b/src/components/calendar/calendar-day.tsx
@@ -88,15 +88,20 @@ export function CalendarDay({
   // "Vaeschanan · Shabbat Nachamu" — the special-Shabbat name rides the parsha line.
   const parshaLine = [info.parsha, specialShabbosLabel].filter(Boolean).join(' · ') || null;
 
-  // Shrink the content to fit a short row instead of clipping it. `zoom` scales
-  // the whole subtree (text, icons, gaps) and — unlike `transform` — affects
-  // layout, so the cell's `overflow-hidden` respects the smaller size. With
-  // standardized `zoom` the element's own percentage width still resolves in
-  // the parent's (unzoomed) space, so the default 100% width already fills the
-  // cell and the children simply get 1/scale more room inside — do NOT
-  // pre-inflate the width, or the wrapper overflows the cell and its right
-  // edge gets clipped.
-  const fitStyle: CSSProperties | undefined = scale < 1 ? { zoom: scale } : undefined;
+  // Shrink the content to fit a short row instead of clipping it: pre-inflate
+  // the width by 1/scale, then transform-scale the subtree back down, so the
+  // scaled result exactly fills the cell and text wraps as if the cell were
+  // 1/scale larger. `zoom` would be the natural tool, but iOS WebKit resolves
+  // rem lengths inside a zoomed subtree against an inversely-zoomed root font
+  // size (WebKit bug 265869), and every size in a cell is rem-based (they must
+  // track the accessibility text scale) — so on iPads zoom was a net no-op and
+  // tall cells clipped. transform math is identical on every engine; the
+  // scaled-down visual result stays inside the cell, and the (unscaled) layout
+  // overflow is cut by the cell's `overflow-hidden`. The origin must be the
+  // top inline-start corner (`origin-top-left rtl:origin-top-right` on the
+  // wrapper) so the visual box hugs the cell's start edge in both directions.
+  const fitStyle: CSSProperties | undefined =
+    scale < 1 ? { width: `${100 / scale}%`, transform: `scale(${scale})` } : undefined;
 
   return (
     <button
@@ -122,7 +127,7 @@ export function CalendarDay({
         isSelected && 'ring-day-selected ring-2 ring-inset',
       )}
     >
-      <div data-day-content className="flex flex-col gap-0.5" style={fitStyle}>
+      <div data-day-content className="flex origin-top-left flex-col gap-0.5 rtl:origin-top-right" style={fitStyle}>
         <div className="flex items-baseline justify-between gap-1">
         <span
           className={cn(

--- a/src/components/calendar/calendar-grid.tsx
+++ b/src/components/calendar/calendar-grid.tsx
@@ -27,7 +27,7 @@ const ESTIMATED_NEED_REM: Record<CellDensity, number> = { full: 5.4, medium: 3.7
 const TIER_ORDER: CellDensity[] = ['full', 'medium', 'compact'];
 const MIN_SCALE = 0.72; // don't shrink text past this before dropping a tier
 // Safety slack against sub-pixel rounding of the `1fr` row tracks and the
-// applied zoom — without it an exact-fit cell can clip its last line by a
+// applied scale — without it an exact-fit cell can clip its last line by a
 // hairline.
 const FIT_SLACK_PX = 1;
 
@@ -41,12 +41,13 @@ interface CellFit {
  * how much to shrink it so it fits without clipping:
  *  · Width picks the base tier (compact → medium → full) — horizontal room.
  *  · In the fixed-viewport (lg+) layout the rows are a height-constrained `1fr`,
- *    so the content is scaled down (via `zoom`) to fit the tallest cell's real
+ *    so the content is scaled down (via a width-compensated transform — see
+ *    `fitStyle` in {@link CalendarDay}) to fit the tallest cell's real
  *    content. Only if it would have to shrink past {@link MIN_SCALE} does the
  *    tier step down.
  * Below lg the grid is content-sized, so height never constrains (scale stays 1).
  *
- * The content height is measured with zoom/width reset to their natural values,
+ * The content height is measured with the width reset to its natural value,
  * so the measurement is independent of the currently applied scale — applying a
  * new fit can't change the next measurement, and there's no oscillation. Tiers
  * that haven't been rendered yet use {@link ESTIMATED_NEED_REM}; choosing one
@@ -92,19 +93,21 @@ function useCellFit(gridRef: RefObject<HTMLDivElement | null>, fontScale: string
       }
 
       // Natural height of the tallest cell's content for the tier currently
-      // rendered. zoom is reset during the read so the result doesn't depend
-      // on the currently applied scale. (Wrapping at natural width is never
-      // looser than at the zoomed width, so this can only overestimate —
-      // content never clips.) The cache is invalidated on every input that
-      // could change the result (content, font scale, cell width, tier), so a
-      // hit — e.g. a height-only resize — skips the whole write/read pass.
+      // rendered. The fit's inflated width is reset during the read so the
+      // result doesn't depend on the currently applied scale (the transform
+      // itself never affects offsetHeight). Wrapping at the natural width is
+      // never looser than at the inflated width, so this can only
+      // overestimate — content never clips. The cache is invalidated on every
+      // input that could change the result (content, font scale, cell width,
+      // tier), so a hit — e.g. a height-only resize — skips the whole
+      // write/read pass.
       if (cache.need[rendered] === undefined) {
         const wrappers = Array.from(el.querySelectorAll<HTMLElement>('[data-day-content]'));
-        const saved = wrappers.map((n) => n.style.getPropertyValue('zoom'));
-        for (const n of wrappers) n.style.setProperty('zoom', '1');
+        const saved = wrappers.map((n) => n.style.getPropertyValue('width'));
+        for (const n of wrappers) n.style.removeProperty('width');
         let needPx = 0;
         for (const n of wrappers) needPx = Math.max(needPx, n.offsetHeight);
-        wrappers.forEach((n, i) => n.style.setProperty('zoom', saved[i]));
+        wrappers.forEach((n, i) => saved[i] && n.style.setProperty('width', saved[i]));
         cache.need[rendered] = needPx / rem;
       }
 

--- a/src/lib/releases.ts
+++ b/src/lib/releases.ts
@@ -18,6 +18,21 @@ export interface Release {
 
 export const RELEASES: readonly Release[] = [
   {
+    version: '1.12',
+    date: '2026-07-06',
+    notes: {
+      en: [
+        'Fixed calendar day cells clipping their times and holiday labels on iPhone/iPad: the shrink-to-fit scaling now sidesteps a WebKit bug that made it a no-op on iOS.',
+      ],
+      he: [
+        'תוקן חיתוך של זמנים ותוויות חגים בתאי הלוח באייפון/אייפד: התאמת הגודל האוטומטית עוקפת כעת באג ב-WebKit שגרם לה לא לפעול ב-iOS.',
+      ],
+      ru: [
+        'Исправлено обрезание времён и названий праздников в ячейках календаря на iPhone/iPad: автоматическое уменьшение содержимого теперь обходит ошибку WebKit, из-за которой оно не работало на iOS.',
+      ],
+    },
+  },
+  {
     version: '1.11',
     date: '2026-07-05',
     notes: {


### PR DESCRIPTION
## Problem

On iPads (old and per open WebKit reports possibly current ones), calendar day cells clipped their times and holiday labels at row boundaries, even though the shrink-to-fit logic from #40 was deployed and working on desktop.

Root cause: [WebKit bug 265869](https://bugs.webkit.org/show_bug.cgi?id=265869) — on iOS/iPadOS WebKit, `rem` lengths inside a `zoom`ed subtree resolve against an inversely-zoomed root font size (`1rem` under `zoom: 0.5` computes to 32px). Every size in a day cell is deliberately rem-based so it tracks the accessibility text scale, so the applied `zoom: <scale>` was a net no-op on iOS: the fit algorithm measured, chose a scale, applied it, and nothing shrank.

## Fix

Stop relying on `zoom` semantics entirely:

- **`calendar-day.tsx`** — the fit pre-inflates the wrapper width to `100/scale%` and applies `transform: scale(scale)` from the top inline-start corner (`origin-top-left rtl:origin-top-right`). Transform math is identical on every engine; the scaled visual result exactly fills the cell and the unscaled layout overflow is cut by the existing `overflow-hidden`.
- **`calendar-grid.tsx`** — the measurement pass resets the inflated `width` instead of `zoom` when reading natural content heights (transforms never affect `offsetHeight`), preserving the no-oscillation property of the measurement.
- **`releases.ts`** — v1.12 release notes (en/he/ru).

## Verification

- lint, typecheck, 208 unit tests, 4 Playwright e2e tests pass.
- Browser-checked the September 2026 month from the bug report at 1024×540 (shorter than the iPad's usable height): Hebrew/RTL applies `scale(0.803)` and the previously-clipped ערב ראש השנה / צום גדליה cells render fully, with visual edges measured flush against the cell padding box on all sides; English/LTR verified the same way at 1024×480.
- Mobile (<1024px) path unchanged: content-sized rows, no scaling, nothing clipped.