### PR TITLE
fix(theme): opt out of browser forced dark modes

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -21,6 +21,12 @@ export const viewport: Viewport = {
   initialScale: 1,
   maximumScale: 1,
   userScalable: false,
+  /* Parse-time "this page has a native dark theme" signal. Chromium-family
+     "force dark web pages" features (CCleaner/Avast browsers, auto-dark)
+     decide from the head metadata whether to run their per-element inversion;
+     without this they can invert our already-dark UI patchily. The theme init
+     script below still sets the effective per-user scheme before paint. */
+  colorScheme: 'light dark',
   themeColor: [
     { media: '(prefers-color-scheme: light)', color: '#ffffff' },
     { media: '(prefers-color-scheme: dark)', color: '#0b1220' },
@@ -47,6 +53,9 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
       ],
       apple: '/icon-192.png',
     },
+    // Tells Dark Reader (and browser dark modes built on it) the site ships
+    // its own dark theme, so it must not re-darken the page.
+    other: { 'darkreader-lock': 'true' },
   };
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -69,7 +69,8 @@
 .export-light {
   /* Declared in CSS as well as via the pre-paint inline style: forced-dark
      browser features read the used color-scheme to decide whether to invert
-     the page, and this keeps the opt-out alive without JS. */
+     the page, and some forks only honor the signal when it comes from a
+     stylesheet, not a script-set inline style. */
   color-scheme: light;
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -67,6 +67,10 @@
    and use no `dark:` variants). */
 :root,
 .export-light {
+  /* Declared in CSS as well as via the pre-paint inline style: forced-dark
+     browser features read the used color-scheme to decide whether to invert
+     the page, and this keeps the opt-out alive without JS. */
+  color-scheme: light;
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
@@ -119,6 +123,7 @@
 }
 
 .dark {
+  color-scheme: dark;
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);


### PR DESCRIPTION
## Problem

A user on CCleaner Browser reported the dark theme "applying partially" — light-gray and pastel-pink patches over the calendar while the rest of the page is dark.

The artifacts are not our theme half-applying: CCleaner Browser (a Chromium fork from the Avast/Gen family) ships a built-in "force dark web pages" feature that runs per-element color inversion on top of the page. On our already-dark UI it flips some dark elements back to light — the light patches are our dark outside-month cells and holiday chips, inverted. Reproduced locally with Chromium's auto-dark override (`Emulation.setAutoDarkModeOverride`) via Playwright.

Stock Chromium leaves our dark theme alone because the pre-paint init script sets `color-scheme: dark` on `<html>`; the fork evidently doesn't pick the opt-out up from a script-set inline style.

## Fix

Broadcast the "this site has a native dark theme" opt-out through every channel forced-dark features actually check:

- `viewport.colorScheme: 'light dark'` → emits a parse-time `<meta name="color-scheme" content="light dark">` in the head, so forks that decide from head metadata (before any script runs) see it
- `<meta name="darkreader-lock" content="true">` — honored by Dark Reader and browser dark modes built on it
- CSS-level `color-scheme: light` on `:root`/`.export-light` and `color-scheme: dark` on `.dark`, so the opt-out also holds without JS

## Verification

- Before/after screenshots under forced auto-dark: native dark theme renders pixel-identical; light theme unaffected in normal browsers; both metas present in the served head
- lint, typecheck, 232 unit tests, Playwright smoke — all green

No changelog entry per maintainer — minor compatibility fix.