### PR TITLE
fix(telegram): show the bot's location names verbatim in the Mini App

### DIFF
--- a/src/components/location/location-picker.tsx
+++ b/src/components/location/location-picker.tsx
@@ -155,7 +155,9 @@ export function LocationPicker() {
     }
     const display = savedLocationDisplayName(entry);
     const detailParts = [
-      entry.name.trim() ? entry.location.label : null,
+      // Skip the geocoded label when it just repeats the display name (bot
+      // entries arrive with name === label).
+      entry.name.trim() && entry.location.label !== entry.name.trim() ? entry.location.label : null,
       typeof entry.location.elevation === 'number' ? `${entry.location.elevation} ${tSettings('meters')}` : null,
     ].filter(Boolean);
     return (

--- a/src/components/providers/telegram-mini-app.tsx
+++ b/src/components/providers/telegram-mini-app.tsx
@@ -31,11 +31,16 @@ function baselineOf(profile: BotProfile): SyncedState {
   };
 }
 
-/** The bot's saved list as picker entries (stable ids so re-renders don't churn). */
+/**
+ * The bot's saved list as picker entries (stable ids so re-renders don't
+ * churn). The bot's name rides as the entry's custom name, so selecting one
+ * keeps it in the header (like the bot shows it) instead of being replaced by
+ * the relabel effect's geocoded city name.
+ */
 function botLocationEntries(profile: BotProfile): SavedLocation[] {
   return profile.locations.map((loc) => ({
     id: `bot:${loc.lat},${loc.lng}`,
-    name: '',
+    name: loc.name,
     location: makeLocation(loc.lat, loc.lng, loc.name, undefined, loc.elevation),
   }));
 }
@@ -72,14 +77,22 @@ export function TelegramMiniApp() {
       if (!profile || cancelled) return;
       synced.current = baselineOf(profile);
       applyBotProfile({
+        // The bot's name rides as customLabel so the header shows it verbatim
+        // («Дом» stays «Дом»); the relabel effect only re-resolves the
+        // underlying geocoded label — otherwise the applied home location
+        // re-geocodes to the user's city name and looks like an auto-detected
+        // "current location" instead of the bot's saved one.
         location: profile.location
-          ? makeLocation(
-              profile.location.lat,
-              profile.location.lng,
-              profile.location.name,
-              undefined,
-              profile.location.elevation,
-            )
+          ? {
+              ...makeLocation(
+                profile.location.lat,
+                profile.location.lng,
+                profile.location.name,
+                undefined,
+                profile.location.elevation,
+              ),
+              customLabel: profile.location.name,
+            }
           : undefined,
         candleLightingOffset:
           profile.clOffset != null


### PR DESCRIPTION
Opening the mini app from the static BotFather button (no `?lat=` deep link) looked like it "used the current location instead of the bot's" — but `/me` was returning the right active location all along. The applied location's name arrived as a plain `label` with no locale tag, so the relabel effect re-geocoded the coordinates: the bot's custom «Дом» rendered as the user's town name, indistinguishable from an auto-detected location (same coordinates — it *is* home).

- The bot's name now rides as `customLabel` on the applied active location, so the header shows it verbatim, like the bot does; the relabel effect still re-resolves the geocoded label underneath.
- Bot entries in the location picker carry the name as the entry's custom name, so *selecting* one also keeps it in the header.
- The picker's detail line skips the geocoded label when it merely repeats the display name (bot entries arrive with `name === label`).

Write-back is unaffected: a location change still pushes `customLabel || label`, so bot names survive round-trips.

No version bump per maintainer preference for small fixes.
