### PR TITLE
fix(compat): degrade gracefully on browsers below the CSS baseline

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -472,7 +472,11 @@
     "chipBatMitzvah": "{label} · bat mitzvah",
     "chipYahrzeit": "{label} · {n, selectordinal, one {#st} two {#nd} few {#rd} other {#th}} yahrzeit"
   },
-  "footer": {
+  "browser": {
+  "unsupported": "Your browser is too old to display this site correctly — please update your browser or system.",
+  "dismiss": "Dismiss"
+ },
+ "footer": {
     "disclaimer": "Zmanim times computed with <link>kosher-zmanim</link>, daily learning with <hebcal>Hebcal</hebcal>. For halachic decisions, consult your local rabbinic authority.",
     "madeBy": "Made by Benyamin Ginzburg",
     "source": "Source"

--- a/messages/he.json
+++ b/messages/he.json
@@ -472,7 +472,11 @@
     "chipBatMitzvah": "{label} · בת מצווה",
     "chipYahrzeit": "{label} · יום השנה ה־{n}"
   },
-  "footer": {
+  "browser": {
+  "unsupported": "הדפדפן שלך ישן מדי להצגה תקינה של האתר — נא לעדכן את הדפדפן או את מערכת ההפעלה.",
+  "dismiss": "סגירה"
+ },
+ "footer": {
     "disclaimer": "הזמנים מחושבים באמצעות <link>kosher-zmanim</link> והלימוד היומי באמצעות <hebcal>Hebcal</hebcal>. להכרעות הלכתיות יש להתייעץ עם רב מוסמך.",
     "madeBy": "מאת Benyamin Ginzburg",
     "source": "קוד"

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -472,7 +472,11 @@
     "chipBatMitzvah": "{label} · бат-мицва",
     "chipYahrzeit": "{label} · {n}-й йорцайт"
   },
-  "footer": {
+  "browser": {
+  "unsupported": "Ваш браузер устарел и не может корректно отобразить сайт — пожалуйста, обновите браузер или систему.",
+  "dismiss": "Закрыть"
+ },
+ "footer": {
     "disclaimer": "Зманим рассчитаны с помощью <link>kosher-zmanim</link>, ежедневное изучение — с помощью <hebcal>Hebcal</hebcal>. Для алахических решений обратитесь к местному раввину.",
     "madeBy": "Сделал Benyamin Ginzburg",
     "source": "Код"

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -10,6 +10,7 @@ import '../globals.css';
 import { AccessibilityProvider } from '@/components/providers/accessibility-provider';
 import { ThemeProvider } from '@/components/providers/theme-provider';
 import { dirForLocale, routing } from '@/i18n/routing';
+import { browserSupportScript } from '@/lib/browser-support';
 import { SITE_NAME, SITE_URL } from '@/lib/site';
 import { themeInitScript } from '@/lib/theme';
 
@@ -69,6 +70,7 @@ export default async function LocaleLayout({
   const { locale } = await params;
   if (!hasLocale(routing.locales, locale)) notFound();
   setRequestLocale(locale);
+  const tBrowser = await getTranslations('browser');
 
   return (
     <html
@@ -89,11 +91,15 @@ export default async function LocaleLayout({
             The beforeinstallprompt stash must also live here: Chrome fires the
             event as soon as installability is validated, which can beat the
             React bundle — use-install-prompt picks the event up from
-            window.__zmanimBip at module load. */}
+            window.__zmanimBip at module load.
+            The last block warns on browsers below the stylesheet's CSS
+            baseline (see src/lib/browser-support.ts) — on those the page
+            renders unstyled, so the notice must come from this inline
+            script, not from React. */}
         <div
           hidden
           dangerouslySetInnerHTML={{
-            __html: `<script>${themeInitScript}(function(){try{var p=JSON.parse(localStorage.getItem('zmanim:a11y:v1')||'{}');var e=document.documentElement;if(p.fontScale&&p.fontScale!=='default')e.classList.add('text-scale-'+p.fontScale);if(p.reduceMotion)e.classList.add('reduce-motion');if(p.highContrast)e.classList.add('high-contrast');}catch(e){}})();window.addEventListener('beforeinstallprompt',function(e){window.__zmanimBip=e},{once:true});</script>`,
+            __html: `<script>${themeInitScript}(function(){try{var p=JSON.parse(localStorage.getItem('zmanim:a11y:v1')||'{}');var e=document.documentElement;if(p.fontScale&&p.fontScale!=='default')e.classList.add('text-scale-'+p.fontScale);if(p.reduceMotion)e.classList.add('reduce-motion');if(p.highContrast)e.classList.add('high-contrast');}catch(e){}})();window.addEventListener('beforeinstallprompt',function(e){window.__zmanimBip=e},{once:true});${browserSupportScript(tBrowser('unsupported'), tBrowser('dismiss'))}</script>`,
           }}
         />
         <ThemeProvider>

--- a/src/components/layout/site-footer.tsx
+++ b/src/components/layout/site-footer.tsx
@@ -37,9 +37,12 @@ function Dot() {
 
 // Brand glyphs — lucide-react dropped its brand icons, so these are inline
 // simple-icons paths (24×24, currentColor) sized to match the footer text.
+// The width/height attributes back up the class: without them a browser that
+// applies none of our CSS (pre-16.4 Safari drops the whole @layer-wrapped
+// stylesheet) inflates each icon to the full viewport width.
 function TelegramIcon(props: SVGProps<SVGSVGElement>) {
   return (
-    <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden className="size-3.5" {...props}>
+    <svg viewBox="0 0 24 24" width={14} height={14} fill="currentColor" aria-hidden className="size-3.5" {...props}>
       <path d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.48.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z" />
     </svg>
   );
@@ -47,7 +50,7 @@ function TelegramIcon(props: SVGProps<SVGSVGElement>) {
 
 function FacebookIcon(props: SVGProps<SVGSVGElement>) {
   return (
-    <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden className="size-3.5" {...props}>
+    <svg viewBox="0 0 24 24" width={14} height={14} fill="currentColor" aria-hidden className="size-3.5" {...props}>
       <path d="M9.101 23.691v-7.98H6.627v-3.667h2.474v-1.58c0-4.085 1.848-5.978 5.858-5.978.401 0 .955.042 1.468.103a8.68 8.68 0 0 1 1.141.195v3.325a8.623 8.623 0 0 0-.653-.036 26.805 26.805 0 0 0-.733-.009c-.707 0-1.259.096-1.675.309a1.686 1.686 0 0 0-.679.622c-.258.42-.374.995-.374 1.752v1.297h3.919l-.386 2.103-.287 1.564h-3.246v8.245C19.396 23.238 24 18.179 24 12.044c0-6.628-5.373-12-12-12s-12 5.372-12 12c0 5.628 3.874 10.35 9.101 11.647Z" />
     </svg>
   );
@@ -55,7 +58,7 @@ function FacebookIcon(props: SVGProps<SVGSVGElement>) {
 
 function GithubIcon(props: SVGProps<SVGSVGElement>) {
   return (
-    <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden className="size-3.5" {...props}>
+    <svg viewBox="0 0 24 24" width={14} height={14} fill="currentColor" aria-hidden className="size-3.5" {...props}>
       <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.91 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222 0 1.606-.014 2.898-.014 3.293 0 .322.216.694.825.576C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
     </svg>
   );

--- a/src/lib/browser-support.ts
+++ b/src/lib/browser-support.ts
@@ -1,0 +1,18 @@
+/**
+ * Outdated-browser notice, inlined into the document by the locale layout the
+ * same way as `themeInitScript` (see src/lib/theme.ts for why it is a plain
+ * string interpolated via innerHTML rather than a React <script>).
+ *
+ * The stylesheet is Tailwind v4 output: everything sits in native `@layer`
+ * blocks and leans on `oklch()`, `color-mix()`, and `@property`. Its baseline
+ * is Safari 16.4 / Chrome 111 / Firefox 128; anything older than Safari 15.4
+ * doesn't parse `@layer` at all and drops the ENTIRE stylesheet, rendering the
+ * page as bare unstyled HTML. This probe mirrors that exact baseline
+ * (`CSSPropertyRule` ⇔ `@property` support) and, when short, prepends a
+ * dismissible banner. The banner is styled inline only — on the browsers it
+ * targets none of our CSS applies — and is inserted before hydration; React 19
+ * ignores unexpected pre-existing nodes in <body> when hydrating.
+ */
+export function browserSupportScript(message: string, dismissLabel: string): string {
+  return `(function(){try{if(window.CSS&&CSS.supports&&CSS.supports('color','oklch(0 0 0)')&&CSS.supports('color','color-mix(in oklab, red, red)')&&typeof CSSPropertyRule!=='undefined')return;var b=document.createElement('div');b.setAttribute('role','alert');b.setAttribute('style','position:fixed;top:0;left:0;right:0;z-index:9999;padding:10px 16px;background:#fde68a;color:#78350f;font:14px/1.5 -apple-system,system-ui,sans-serif;text-align:center;border-bottom:1px solid #d97706');b.appendChild(document.createTextNode(${JSON.stringify(message)}));var x=document.createElement('button');x.setAttribute('aria-label',${JSON.stringify(dismissLabel)});x.setAttribute('style','margin-inline-start:12px;border:0;padding:0;background:none;color:inherit;font:inherit;cursor:pointer');x.appendChild(document.createTextNode('\\u2715'));x.onclick=function(){if(b.parentNode)b.parentNode.removeChild(b)};b.appendChild(x);document.body.insertBefore(b,document.body.firstChild);}catch(e){}})();`;
+}

--- a/src/lib/releases.test.ts
+++ b/src/lib/releases.test.ts
@@ -35,7 +35,17 @@ describe('releasesSince', () => {
 
   it('returns only the releases newer than the last seen version', () => {
     const unseen = releasesSince('1.12');
-    expect(unseen.map((r) => r.version)).toEqual(['1.20', '1.19', '1.18', '1.17', '1.16', '1.15', '1.14', '1.13']);
+    expect(unseen.map((r) => r.version)).toEqual([
+      '1.21',
+      '1.20',
+      '1.19',
+      '1.18',
+      '1.17',
+      '1.16',
+      '1.15',
+      '1.14',
+      '1.13',
+    ]);
   });
 
   it('treats a corrupted stored version as older than everything', () => {

--- a/src/lib/releases.ts
+++ b/src/lib/releases.ts
@@ -21,6 +21,15 @@ export interface Release {
 
 export const RELEASES: readonly Release[] = [
   {
+    version: '1.21',
+    date: '2026-07-19',
+    notes: {
+      en: ['Very old browsers that can’t render the site now get a clear update notice instead of a broken page.'],
+      he: ['דפדפנים ישנים שאינם יכולים להציג את האתר מקבלים כעת הודעת עדכון ברורה במקום עמוד שבור.'],
+      ru: ['Устаревшие браузеры, не способные отобразить сайт, теперь видят понятное предложение обновиться вместо сломанной страницы.'],
+    },
+  },
+  {
     version: '1.20',
     date: '2026-07-16',
     notes: {


### PR DESCRIPTION
## Problem

A user on Safari 15.2 saw the site as a giant blue shape over bare unstyled HTML. The Tailwind v4 stylesheet sits entirely in native `@layer` blocks, which pre-15.4 Safari doesn't parse — the whole sheet is dropped. With no CSS, the footer's inline brand SVGs (no intrinsic size, `currentColor` inside a link) inflate to the viewport width in default link blue, and the JS bundle dies too, so the calendar never mounts.

## Changes

- Footer brand icons get intrinsic `width`/`height` attributes (14px, matching `size-3.5`) so a CSS-less render stays readable; when CSS applies, the class still governs — no visual change on supported browsers.
- New `src/lib/browser-support.ts`: an inline script (same innerHTML pattern as `themeInitScript`) probes the stylesheet's actual baseline — `oklch()`, `color-mix()`, `@property` (Safari 16.4 / Chrome 111 / Firefox 128) — and on unsupported browsers prepends a dismissible, inline-styled banner asking the user to update. Text is localized in all three catalogs (new `browser` namespace); the banner uses inline styles only, since none of our CSS applies where it shows.
- Version bumped to 1.21 with release notes in en/he/ru.

## Verification

- `lint` / `typecheck` / `test` pass (383 tests, pinned release-list test updated).
- Verified in-browser against the dev server: modern Chrome gets no banner and unchanged 14px icons; re-running the emitted script with the feature probe defeated shows the localized banner as `body`'s first child, dismiss removes it, console stays clean. All three locales embed their translated message.