### PR TITLE
feat(web): surface the bot's saved locations after Login Widget sign-in

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -17,6 +17,7 @@ import { AppStateProvider, type AppLocation } from '@/components/providers/app-s
 import { QueryProvider } from '@/components/providers/query-provider';
 import { SettingsSync } from '@/components/providers/settings-sync';
 import { TelegramMiniApp } from '@/components/providers/telegram-mini-app';
+import { WebBotProfile } from '@/components/providers/web-bot-profile';
 import { Skeleton } from '@/components/ui/skeleton';
 import { ZmanimPanel } from '@/components/zmanim/zmanim-panel';
 import { useHeaderStage } from '@/hooks/use-header-stage';
@@ -57,6 +58,8 @@ export function App({ initialLocation }: { initialLocation?: AppLocation }) {
       <AppStateProvider initialLocation={initialLocation}>
         {/* No-op outside Telegram; inside it, sets up the webview and syncs the bot profile. */}
         <TelegramMiniApp />
+        {/* On the plain web, signed in via the Login Widget: pulls the bot's saved locations. */}
+        <WebBotProfile />
         {/* Mount-gated: it reconciles localStorage with the connected sync stores. */}
         {mounted && <SettingsSync />}
         {/* Desktop (lg+): a fixed-viewport shell that never scrolls — the

--- a/src/components/providers/telegram-mini-app.tsx
+++ b/src/components/providers/telegram-mini-app.tsx
@@ -37,7 +37,7 @@ function baselineOf(profile: BotProfile): SyncedState {
  * keeps it in the header (like the bot shows it) instead of being replaced by
  * the relabel effect's geocoded city name.
  */
-function botLocationEntries(profile: BotProfile): SavedLocation[] {
+export function botLocationEntries(profile: BotProfile): SavedLocation[] {
   return profile.locations.map((loc) => ({
     id: `bot:${loc.lat},${loc.lng}`,
     name: loc.name,

--- a/src/components/providers/web-bot-profile.tsx
+++ b/src/components/providers/web-bot-profile.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { useAppState } from '@/components/providers/app-state';
+import { botLocationEntries } from '@/components/providers/telegram-mini-app';
+import { botSyncEnabled, fetchBotProfile } from '@/lib/telegram/bot-sync';
+import { isTelegramMiniApp } from '@/lib/telegram/mini-app';
+import { loadTelegramWebAuth, WEB_AUTH_EVENT } from '@/lib/telegram/web-login';
+
+/**
+ * On the plain website, once signed in with the Telegram Login Widget, surface
+ * the bot's saved locations in the picker — the same list the Mini App shows
+ * from initData, here fetched with the stored web auth. (Renders nothing.)
+ *
+ * The settings blob syncs everything else; the bot's `locations` list isn't in
+ * it, so it's fetched separately. Inside the Mini App this is handled by
+ * TelegramMiniApp instead.
+ */
+export function WebBotProfile() {
+  const { applyBotProfile } = useAppState();
+
+  useEffect(() => {
+    if (isTelegramMiniApp()) return; // the Mini App provider owns that context
+    let cancelled = false;
+    const pull = () => {
+      const auth = loadTelegramWebAuth();
+      if (!botSyncEnabled() || !auth) return;
+      void fetchBotProfile({ authData: { ...auth } }).then((profile) => {
+        if (profile && !cancelled) applyBotProfile({ botLocations: botLocationEntries(profile) });
+      });
+    };
+    pull(); // on load, if already signed in
+    window.addEventListener(WEB_AUTH_EVENT, pull); // and right after a fresh sign-in
+    return () => {
+      cancelled = true;
+      window.removeEventListener(WEB_AUTH_EVENT, pull);
+    };
+  }, [applyBotProfile]);
+
+  return null;
+}

--- a/src/lib/releases.test.ts
+++ b/src/lib/releases.test.ts
@@ -36,6 +36,7 @@ describe('releasesSince', () => {
   it('returns only the releases newer than the last seen version', () => {
     const unseen = releasesSince('1.12');
     expect(unseen.map((r) => r.version)).toEqual([
+      '1.23',
       '1.22',
       '1.21',
       '1.20',

--- a/src/lib/releases.ts
+++ b/src/lib/releases.ts
@@ -21,6 +21,15 @@ export interface Release {
 
 export const RELEASES: readonly Release[] = [
   {
+    version: '1.23',
+    date: '2026-07-21',
+    notes: {
+      en: ['Signed in with Telegram on the web, your bot’s saved locations now appear in the location picker.'],
+      he: ['לאחר התחברות עם טלגרם באתר, המיקומים השמורים בבוט מופיעים כעת בבוחר המיקומים.'],
+      ru: ['После входа через Telegram на сайте сохранённые в боте локации теперь появляются в выборе локации.'],
+    },
+  },
+  {
     version: '1.22',
     date: '2026-07-20',
     notes: {

--- a/src/lib/telegram/web-login.ts
+++ b/src/lib/telegram/web-login.ts
@@ -62,9 +62,13 @@ export function loadTelegramWebAuth(): TelegramWebAuth | null {
   }
 }
 
+/** Fired after sign-in/sign-out so listeners (e.g. WebBotProfile) can react. */
+export const WEB_AUTH_EVENT = 'zmanim:web-auth';
+
 export function saveTelegramWebAuth(auth: TelegramWebAuth): void {
   try {
     window.localStorage.setItem(AUTH_KEY, JSON.stringify(auth));
+    window.dispatchEvent(new Event(WEB_AUTH_EVENT));
   } catch {
     // Sync will simply not persist across reloads.
   }


### PR DESCRIPTION
## What

On the plain website, once signed in with the Telegram **Login Widget**, the location picker now lists the user's **bot-saved locations** — the same list the Mini App already shows. Previously the web sign-in synced only the settings blob and never fetched the bot's structured `locations` list.

## How

- New read-only `WebBotProfile` provider: fetches the bot profile with the stored web auth and applies its `locations` to the picker (`applyBotProfile({ botLocations })`). Refreshes on load and right after a fresh sign-in (`WEB_AUTH_EVENT` dispatched by `saveTelegramWebAuth`).
- Reuses the Mini App's `botLocationEntries` (now exported).

## Web edits never touch the bot's own settings

By design and verified: the mini-app write-back that pushes `location`/`cl_offset`/`havdala_opinion` is gated to run **only** inside Telegram (returns early on web), and the web sync target pushes **only** the opaque `web_prefs` blob. So editing settings on the web updates the site's synced settings, never the bot's location/candle/havdalah that the bot uses for its own features. `WebBotProfile` is read-only.

## Notes

- Bumps to **v1.23** (release note in all three locales).
- This change briefly landed on `main` (`2be3df3`) by mistake and was reverted there (`97beb4c`); this PR reintroduces it via review.