### PR TITLE
fix(sync): never adopt an absent remote section over a present value

### DIFF
--- a/src/lib/sync/blob.test.ts
+++ b/src/lib/sync/blob.test.ts
@@ -114,6 +114,20 @@ describe('mergeBlobs (per-section, newest wins)', () => {
     expect(mergeBlobs([a, b]).sections.theme.data).toBe(winner);
     expect(mergeBlobs([b, a]).sections.theme.data).toBe(winner); // order-independent
   });
+
+  it('never lets an absent (null) section win over a present value', () => {
+    // A partial remote blob (e.g. web_prefs with no language section) carries
+    // language {null, EPOCH}. The equal-stamp fingerprint tie-break would pick
+    // null ("null" > '"en"'), which the reconcile then "adopts" every mount —
+    // an infinite reload, since language lives in the URL, not localStorage.
+    const present = blob({ language: { data: 'en', t: EPOCH } });
+    const absent = blob({ language: { data: null, t: EPOCH } });
+    expect(mergeBlobs([present, absent]).sections.language.data).toBe('en');
+    expect(mergeBlobs([absent, present]).sections.language.data).toBe('en'); // order-independent
+    // A present value beats an absent one even when the absent side is stamped later.
+    const absentLater = blob({ language: { data: null, t: '2099-01-01T00:00:00.000Z' } });
+    expect(mergeBlobs([present, absentLater]).sections.language.data).toBe('en');
+  });
 });
 
 describe('changedSections', () => {

--- a/src/lib/sync/blob.ts
+++ b/src/lib/sync/blob.ts
@@ -261,13 +261,27 @@ export function recordSyncedPrefs(fingerprint: string): void {
 }
 
 /**
- * A total order over a section's two versions: newer stamp wins, and on an
- * equal stamp the larger fingerprint wins. The tie-break guarantees two
- * diverged devices converge on the same winner instead of each re-pushing its
- * own copy forever (equal stamps happen when one device adopts a section, then
- * a change whose debounced push is lost leaves the stamp unbumped).
+ * A total order over a section's two versions: a present value always beats an
+ * absent one; otherwise newer stamp wins, and on an equal stamp the larger
+ * fingerprint wins. The tie-break guarantees two diverged devices converge on
+ * the same winner instead of each re-pushing its own copy forever (equal stamps
+ * happen when one device adopts a section, then a change whose debounced push is
+ * lost leaves the stamp unbumped).
+ *
+ * `null` data means the section is ABSENT (there is no UI to set a section to
+ * null — a reset writes a real default like theme `system`), so it must never
+ * win over a present value, at ANY stamp. Without this, a store holding a
+ * partial blob (e.g. web_prefs with no language section => language {null,
+ * EPOCH}) beats the device's real value and the reconcile "adopts" the absent
+ * section every mount. Language is the pathological case: it lives in the URL,
+ * never localStorage, so adopting null can't change what the next load reads —
+ * reconcile re-adopts it forever, reloading the page in an infinite loop.
  */
 function sectionIsNewer(name: SectionName, a: BlobSection, b: BlobSection): boolean {
+  const aAbsent = a.data === null;
+  const bAbsent = b.data === null;
+  if (aAbsent !== bAbsent) return !aAbsent; // a present value always wins
+
   const ta = Date.parse(a.t);
   const tb = Date.parse(b.t);
   if (ta !== tb) return ta > tb;

--- a/src/lib/sync/engine.test.ts
+++ b/src/lib/sync/engine.test.ts
@@ -141,6 +141,28 @@ describe('reconcileTargets', () => {
     expect(Date.parse(state.blob!.sections.language.t)).toBeGreaterThan(Date.parse('2099-01-01T00:00:00.000Z'));
   });
 
+  it('does not adopt (reload) forever when a store lacks the language section', async () => {
+    // The reported infinite-reload bug: a logged-in web user on default English
+    // whose bot web_prefs blob has no language section -> language {null, EPOCH}.
+    // The device's language is 'en' (from the URL) at EPOCH. Adopting the null
+    // could never change what the next load reads (language is not in
+    // localStorage), so a naive tie-break re-adopts it every mount and reloads.
+    document.documentElement.lang = 'en';
+    window.localStorage.setItem(PREFS_STORAGE_KEY, JSON.stringify({ candleLightingOffset: 18 }));
+    const { target, state } = memoryTarget(blob({ prefs: { data: { candleLightingOffset: 18 }, t: EPOCH } }));
+
+    const first = await reconcileTargets([target]);
+    expect(first.outcome).not.toBe('applied'); // no reload
+    expect(first.appliedLanguage).toBeNull();
+    // The device fixes the store instead: its real language ('en') is pushed out.
+    expect(state.blob?.sections.language.data).toBe('en');
+
+    // A reload cannot change the URL-derived language; a second run must agree.
+    document.documentElement.lang = 'en';
+    const second = await reconcileTargets([target]);
+    expect(second.outcome).toBe('clean');
+  });
+
   it('reports the adopted language so the caller can switch locale', async () => {
     document.documentElement.lang = 'en';
     stampSection('language', '2026-07-20T09:00:00.000Z');


### PR DESCRIPTION
## The bug

Signed-in users saw the site reload endlessly. Being logged in adds the bot's `web_prefs` as a sync store, so every load runs the reconcile in `SettingsSync` against it.

A connected store can hold a **partial blob** whose `language` section is absent — stored as `{data: null, t: EPOCH}`. In the merge, equal-stamp ties are broken by "larger fingerprint wins", and `JSON.stringify(null)` (`"null"`) sorts above `"en"`. So the absent section beat the device's real language and the reconcile **adopted** it on every mount.

`language` is the fatal case: it lives in the URL, never localStorage, so `applyBlobSections` can't actually write it. A reload can't change what the next load reads → the reconcile re-adopts `null` → `reloadForSync` reloads → forever.

## The fix

In `sectionIsNewer`, **a present value always beats an absent (`null`) one, at any stamp.** There is no UI that sets a section to `null` (a reset writes a real default such as theme `system`), so `null` only ever means "this store never had this section" and must never overwrite a real value. The device now keeps its value and **pushes** it out to heal the store (outcome `pushed`, no reload); the next run is `clean`. This also closes the same null-adoption loop for `prefs` / `theme` / `a11y`.

## Tests
- `blob.test.ts` — merge: a present value beats an absent one (both stamp orders, and when the absent side is stamped later).
- `engine.test.ts` — reconcile doesn't reload-loop when a store lacks the language section; it pushes the real value and the second run is `clean`.
- `npm run lint` / `npm run typecheck` clean; full suite passing.

## Not covered
A second, much rarer loop class remains untouched: a store whose `prefs` content is real-but-different and whose fingerprint sorts above the app's normalized re-persist (both non-null, equal stamps). It needs its own reproduction; flagged for follow-up if it surfaces.